### PR TITLE
fixed description of send message API in MCP

### DIFF
--- a/mcp/src/agentmail_mcp/tools/email.py
+++ b/mcp/src/agentmail_mcp/tools/email.py
@@ -10,7 +10,7 @@ client = None
 def setup_client(api_key: Optional[str] = None):
     """Setup the API client with authentication."""
     global client
-    
+
     headers = {}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
@@ -226,7 +226,7 @@ def register_tools(mcp):
         
         Args:
             inbox_id: ID of the sending inbox
-            to: Recipient email addresses
+            to: List of recipient email addresses
             subject: Email subject
             body: Email body content
             cc: CC recipients

--- a/mcp/src/agentmail_mcp/tools/email.py
+++ b/mcp/src/agentmail_mcp/tools/email.py
@@ -153,7 +153,8 @@ def register_tools(mcp):
             
         result = await make_api_request("GET", f"/inboxes/{inbox_id}/threads", params=params)
         return str(result)
-    
+
+    # modified to be slimmer and easier to understand
     @mcp.tool(description="Get thread by ID")
     async def getThread(inbox_id: str, thread_id: str) -> str:
         """
@@ -164,6 +165,20 @@ def register_tools(mcp):
             thread_id: ID of the thread to retrieve
         """
         result = await make_api_request("GET", f"/inboxes/{inbox_id}/threads/{thread_id}")
+        # Clean up messages in the result
+        if isinstance(result, dict) and "messages" in result:
+            cleaned_messages = []
+            for msg in result["messages"]:
+                cleaned_msg = {
+                    "message_id": msg.get("message_id"),
+                    "timestamp": msg.get("timestamp"),
+                    "from": msg.get("from"),
+                    "to": msg.get("to"),
+                    "subject": msg.get("subject"),
+                    "text": msg.get("text"),
+                }
+                cleaned_messages.append(cleaned_msg)
+            result["messages"] = cleaned_messages
         return str(result)
     
     # Message operations


### PR DESCRIPTION
Previous description would cause agent to send an email address not wrapped in an array, which is then invalid input to API. Tested on modified description and am now able to send modified messages via MCP with qwen2.5:7b-instruct.