### PR TITLE
fix: replace z.base64() with z.string() for Gemini compatibility

### DIFF
--- a/node/src/schemas.ts
+++ b/node/src/schemas.ts
@@ -41,7 +41,7 @@ export const GetAttachmentParams = z.object({
 const AttachmentSchema = z.object({
     filename: z.string().optional().describe('Filename'),
     content_id: z.string().optional().describe('Content ID for inline attachments'),
-    content: z.base64().optional().describe('Base64 encoded content'),
+    content: z.string().optional().describe('Base64 encoded content'),
     url: z.url().optional().describe('URL'),
 })
 


### PR DESCRIPTION
## Summary

- Replace `z.base64()` with `z.string()` in `AttachmentSchema.content` field
- `z.base64()` generates `contentEncoding: "base64"` in JSON Schema output, which Google Gemini's function calling API does not support
- This causes 400 errors for all tools that include attachments (`send_message`, `reply_to_message`, `forward_message`)

## Problem

When MCP tools are registered with Gemini models, the generated JSON Schema includes:

```json
{
  "content": {
    "type": "string",
    "contentEncoding": "base64",
    "format": "base64",
    "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*..."
  }
}
```

Gemini only supports a subset of JSON Schema (`type`, `description`, `enum`, `items`, `properties`, `required`, `format`, `nullable`) and rejects `contentEncoding` with:

```
Unknown name "contentEncoding" at 'request.tools[0].function_declarations[N].parameters...'
```

## Fix

`z.string()` produces a clean `{"type": "string"}` schema that all providers accept. The `.describe('Base64 encoded content')` already communicates the expected format to the LLM. Runtime behavior is unchanged since base64 strings are valid strings.

## References

- agentmail-to/agentmail-mcp#8
- [Gemini function calling schema docs](https://ai.google.dev/gemini-api/docs/function-calling#function_declarations)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace AttachmentSchema.content from z.base64() to z.string() to produce Gemini-compatible JSON Schema. This removes the unsupported contentEncoding field and fixes 400 errors when registering tools with attachments (e.g., send_message, reply_to_message, forward_message).

<sup>Written for commit 8dbea9ecd13a507380709a1f91e26079d72fa73c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

