### PR TITLE
fix: remove structuredContent from MCP tool results

### DIFF
--- a/node/src/mcp.ts
+++ b/node/src/mcp.ts
@@ -31,7 +31,6 @@ export class AgentMailToolkit extends ListToolkit<McpTool> {
                 const { isError, result } = await safeFunc(tool.func, this.client, args)
                 return {
                     content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-                    structuredContent: result,
                     isError,
                 }
             },


### PR DESCRIPTION
## Summary

- Removes the `structuredContent` field from MCP tool callback results in `node/src/mcp.ts`
- Fixes [agentmail-to/agentmail-mcp#5](https://github.com/agentmail-to/agentmail-mcp/issues/5) — Claude Code and other spec-compliant MCP clients reject tool results with `MCP error -32602`

## Root Cause

The `structuredContent` field in the MCP spec requires tools to declare an `outputSchema`. Since these tools don't declare one, the SDK validates `structuredContent` against no schema and fails. Additionally, when the API result is a string (e.g. from `deleteInbox`), validation fails with "expected record, received string".

The `content` field already returns the full result as pretty-printed JSON text, so no information is lost.

## Test plan

- [ ] Install the patched `agentmail-toolkit` in `agentmail-mcp`
- [ ] Run `claude mcp list` to verify server connects
- [ ] Call `list_inboxes` from Claude Code — should return results without `-32602` error
- [ ] Call `delete_inbox` (string result) — should also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed structuredContent from MCP tool results to comply with the spec when no outputSchema is declared. Fixes MCP error -32602 in Claude Code and other spec-compliant clients while preserving full output via the content field as pretty-printed JSON (agentmail-to/agentmail-mcp#5).

<sup>Written for commit c29f407f77dc319bf52242915889bc397b075910. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

