### PR TITLE
fix: use z.string() for attachment content to fix Gemini compatibility

### DIFF
--- a/node/src/schemas.ts
+++ b/node/src/schemas.ts
@@ -41,7 +41,7 @@ export const GetAttachmentParams = z.object({
 const AttachmentSchema = z.object({
     filename: z.string().optional().describe('Filename'),
     content_id: z.string().optional().describe('Content ID for inline attachments'),
-    content: z.base64().optional().describe('Base64 encoded content'),
+    content: z.string().optional().describe('Base64 encoded content'),
     url: z.url().optional().describe('URL'),
 })
 


### PR DESCRIPTION
## Summary

- Replaces `z.base64()` with `z.string()` for the attachment `content` field in the schema
- `z.base64()` produces a `contentEncoding: "base64"` field in the JSON Schema output, which Google Gemini's function calling API does not support
- This caused tool registration to fail for `send_message`, `reply_to_message`, and `forward_message` tools when used with any Gemini model

The description `'Base64 encoded content'` is preserved so consumers still know to provide base64 data.

Fixes agentmail-to/agentmail-mcp#8

## Test plan

- [ ] Verify MCP tools register successfully with Gemini models
- [ ] Verify attachment content still works with base64 strings via Claude/OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the attachment content field from z.base64() to z.string() to avoid emitting contentEncoding in the JSON Schema, which Gemini’s function-calling API does not support. This unblocks MCP tool registration (send_message, reply_to_message, forward_message) with Gemini, while keeping the "Base64 encoded content" description so clients still send base64 strings.

<sup>Written for commit 342d8dc43a02c6600e8e4493b6c0b41564ec2f1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

