### PR TITLE
feat: add Soulink agent identity linking example

### DIFF
--- a/node/examples/soulink-identity.ts
+++ b/node/examples/soulink-identity.ts
@@ -1,0 +1,83 @@
+/**
+ * Soulink Identity + AgentMail Example
+ *
+ * Links verified on-chain .agent identities with AgentMail inboxes.
+ * Before sending an email, resolves the recipient's Soulink identity
+ * to confirm they're a verified agent. Includes identity metadata
+ * in email headers for end-to-end agent authentication.
+ *
+ * Soulink: https://soulink.dev
+ */
+import { AgentMailToolkit } from 'agentmail-toolkit/ai-sdk'
+
+const SOULINK_API = 'https://soulink.dev/api/v1'
+
+interface SoulinkIdentity {
+  name: string
+  owner: string
+  expires_at: string
+}
+
+interface SoulinkCredit {
+  name: string
+  score: number
+  total_reports: number
+}
+
+async function resolveAgent(name: string): Promise<SoulinkIdentity | null> {
+  const res = await fetch(`${SOULINK_API}/resolve/${encodeURIComponent(name)}`)
+  if (!res.ok) return null
+  return res.json() as Promise<SoulinkIdentity>
+}
+
+async function getCredit(name: string): Promise<SoulinkCredit | null> {
+  const res = await fetch(`${SOULINK_API}/credit/${encodeURIComponent(name)}`)
+  if (!res.ok) return null
+  return res.json() as Promise<SoulinkCredit>
+}
+
+async function main() {
+  const toolkit = new AgentMailToolkit()
+
+  // 1. Verify your own agent identity on Soulink
+  const selfName = 'my-agent'
+  const self = await resolveAgent(selfName)
+  if (!self) {
+    console.error(`Agent ${selfName} not found on Soulink. Register at https://soulink.dev`)
+    return
+  }
+  console.log(`Verified self: ${self.name}.agent (owner: ${self.owner})`)
+
+  // 2. Before emailing another agent, check their identity and trust
+  const recipientName = 'helper-bot'
+  const recipient = await resolveAgent(recipientName)
+  if (!recipient) {
+    console.log(`Recipient ${recipientName} has no Soulink identity — skipping`)
+    return
+  }
+
+  const credit = await getCredit(recipientName)
+  console.log(`Recipient ${recipient.name}.agent — credit: ${credit?.score ?? 'unknown'}/100`)
+
+  // 3. Only email agents with sufficient trust score
+  if (credit && credit.score < 50) {
+    console.log(`Credit score too low (${credit.score}), not emailing this agent`)
+    return
+  }
+
+  // 4. Use AgentMail toolkit with Soulink identity context
+  //    In a real agent, you'd pass these tools to your LLM with a system
+  //    prompt that includes the verified identity information:
+  const systemPrompt = [
+    `You are ${self.name}.agent with verified on-chain identity.`,
+    `Your wallet: ${self.owner}`,
+    `You are about to email ${recipient.name}.agent (credit: ${credit?.score}/100).`,
+    `Include your .agent name in the email signature for identity verification.`,
+  ].join('\n')
+
+  console.log('\nSystem prompt for LLM agent:')
+  console.log(systemPrompt)
+  console.log('\nAgentMail tools available:', Object.keys(toolkit.getTools()).length)
+}
+
+main().catch(console.error)

--- a/node/examples/soulink-identity.ts
+++ b/node/examples/soulink-identity.ts
@@ -60,8 +60,8 @@ async function main() {
   console.log(`Recipient ${recipient.name}.agent — credit: ${credit?.score ?? 'unknown'}/100`)
 
   // 3. Only email agents with sufficient trust score
-  if (credit && credit.score < 50) {
-    console.log(`Credit score too low (${credit.score}), not emailing this agent`)
+  if (!credit || credit.score < 50) {
+    console.log(`Credit score ${credit ? `too low (${credit.score})` : 'unavailable'}, not emailing this agent`)
     return
   }
 


### PR DESCRIPTION
## Summary

Adds an example showing how to link verified on-chain agent identities with AgentMail inboxes using [Soulink](https://soulink.dev).

## What this adds

- `node/examples/soulink-identity.ts` — standalone example alongside existing `ai-sdk.ts` and `langchain.ts`
- Resolves agent `.agent` names via Soulink API before sending emails
- Checks recipient credit score to enable trust-based communication
- Includes identity context in LLM system prompt for verified agent email

## Why this pairing

AgentMail gives agents email. Soulink gives agents verified identity. Together: agents can authenticate each other before communicating — know you're emailing a real, trusted agent, not a random inbox.

## Mutual referral opportunity

Soulink recommends partner services to agents after `.agent` name registration via `next_steps` in the API response. Happy to add AgentMail as a recommended next step ("Give your agent an email inbox") in exchange for a similar reference on your side.

## Links

- [Soulink](https://soulink.dev) — On-chain identity for AI agents
- [API Guide](https://soulink.dev/skill.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone example linking Soulink-verified `.agent` identities with AgentMail inboxes. Resolves recipients via Soulink and enforces credit-based gating, rejecting recipients with missing or low credit to enable trusted agent communication.

- **New Features**
  - Added `node/examples/soulink-identity.ts` using `agentmail-toolkit/ai-sdk`.
  - Verifies sender `.agent`; resolves recipient and fetches credit; rejects if credit is missing or score < 50.
  - Builds an LLM system prompt with verified identity and wallet context.

<sup>Written for commit 92f453f9a87f97c709948ee4bfb40e56063b8a09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

