### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The AgentMail Toolkit integrates popular agent frameworks and protocols including OpenAI Agents SDK, Vercel AI SDK, and Model Context Protocol (MCP) with the AgentMail API.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/agentmail-toolkit-mcp).
+
 ## Setup & Usage
 
 See the [Python](/python) and [Node](/node) packages for language specific setup and usage.


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/agentmail-toolkit-mcp).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "Hosted deployment" section to the README that links to the Fronteir AI hosted instance. This gives users a quick way to try AgentMail Toolkit without self-hosting.

<sup>Written for commit adad2eb43dcc9cca5c2795aff42cfa2a372c5c63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

