### PR TITLE
AddDraftTools

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agentmail-toolkit",
-    "version": "0.2.7",
+    "version": "0.3.0",
     "description": "AgentMail Toolkit",
     "scripts": {
         "build": "tsup",

--- a/node/src/functions.ts
+++ b/node/src/functions.ts
@@ -72,3 +72,35 @@ export async function updateMessage(client: AgentMailClient, args: Args) {
     const { inboxId, messageId, ...options } = args
     return client.inboxes.messages.update(inboxId, messageId, options)
 }
+
+// Draft functions
+
+export async function createDraft(client: AgentMailClient, args: Args) {
+    const { inboxId, ...options } = args
+    return client.inboxes.drafts.create(inboxId, options)
+}
+
+export async function listDrafts(client: AgentMailClient, args: Args) {
+    const { inboxId, ...options } = args
+    return client.inboxes.drafts.list(inboxId, options)
+}
+
+export async function getDraft(client: AgentMailClient, args: Args) {
+    const { inboxId, draftId } = args
+    return client.inboxes.drafts.get(inboxId, draftId)
+}
+
+export async function updateDraft(client: AgentMailClient, args: Args) {
+    const { inboxId, draftId, ...options } = args
+    return client.inboxes.drafts.update(inboxId, draftId, options)
+}
+
+export async function sendDraft(client: AgentMailClient, args: Args) {
+    const { inboxId, draftId } = args
+    return client.inboxes.drafts.send(inboxId, draftId, {})
+}
+
+export async function deleteDraft(client: AgentMailClient, args: Args) {
+    const { inboxId, draftId } = args
+    return client.inboxes.drafts.delete(inboxId, draftId)
+}

--- a/node/src/schemas.ts
+++ b/node/src/schemas.ts
@@ -79,18 +79,14 @@ export const UpdateMessageParams = z.object({
 
 // Draft schemas
 
-export const CreateDraftParams = z.object({
-    inboxId: InboxIdSchema,
+export const CreateDraftParams = BaseMessageParams.extend({
     to: z.array(z.string()).optional().describe('Recipients'),
     cc: z.array(z.string()).optional().describe('CC recipients'),
     bcc: z.array(z.string()).optional().describe('BCC recipients'),
     subject: z.string().optional().describe('Subject'),
-    text: z.string().optional().describe('Plain text body'),
-    html: z.string().optional().describe('HTML body'),
     replyTo: z.array(z.string()).optional().describe('Reply-to addresses'),
     inReplyTo: z.string().optional().describe('Message ID this draft is replying to'),
     sendAt: z.string().pipe(z.coerce.date()).optional().describe('ISO 8601 datetime to schedule sending (e.g. 2026-04-01T09:00:00Z)'),
-    labels: z.array(z.string()).optional().describe('Labels'),
 })
 
 export const ListDraftsParams = ListInboxItemsParams

--- a/node/src/schemas.ts
+++ b/node/src/schemas.ts
@@ -4,6 +4,7 @@ const InboxIdSchema = z.string().describe('ID of inbox')
 const ThreadIdSchema = z.string().describe('ID of thread')
 const MessageIdSchema = z.string().describe('ID of message')
 const AttachmentIdSchema = z.string().describe('ID of attachment')
+const DraftIdSchema = z.string().describe('ID of draft')
 
 export const ListItemsParams = z.object({
     limit: z.number().optional().default(10).describe('Max number of items to return'),
@@ -74,4 +75,50 @@ export const UpdateMessageParams = z.object({
     messageId: MessageIdSchema,
     addLabels: z.array(z.string()).optional().describe('Labels to add'),
     removeLabels: z.array(z.string()).optional().describe('Labels to remove'),
+})
+
+// Draft schemas
+
+export const CreateDraftParams = z.object({
+    inboxId: InboxIdSchema,
+    to: z.array(z.string()).optional().describe('Recipients'),
+    cc: z.array(z.string()).optional().describe('CC recipients'),
+    bcc: z.array(z.string()).optional().describe('BCC recipients'),
+    subject: z.string().optional().describe('Subject'),
+    text: z.string().optional().describe('Plain text body'),
+    html: z.string().optional().describe('HTML body'),
+    replyTo: z.array(z.string()).optional().describe('Reply-to addresses'),
+    inReplyTo: z.string().optional().describe('Message ID this draft is replying to'),
+    sendAt: z.string().optional().describe('ISO 8601 datetime to schedule sending (e.g. 2026-04-01T09:00:00Z)'),
+    labels: z.array(z.string()).optional().describe('Labels'),
+})
+
+export const ListDraftsParams = ListInboxItemsParams
+
+export const GetDraftParams = z.object({
+    inboxId: InboxIdSchema,
+    draftId: DraftIdSchema,
+})
+
+export const UpdateDraftParams = z.object({
+    inboxId: InboxIdSchema,
+    draftId: DraftIdSchema,
+    to: z.array(z.string()).optional().describe('Recipients'),
+    cc: z.array(z.string()).optional().describe('CC recipients'),
+    bcc: z.array(z.string()).optional().describe('BCC recipients'),
+    subject: z.string().optional().describe('Subject'),
+    text: z.string().optional().describe('Plain text body'),
+    html: z.string().optional().describe('HTML body'),
+    replyTo: z.array(z.string()).optional().describe('Reply-to addresses'),
+    sendAt: z.string().optional().describe('ISO 8601 datetime to reschedule sending'),
+})
+
+export const SendDraftParams = z.object({
+    inboxId: InboxIdSchema,
+    draftId: DraftIdSchema,
+})
+
+export const DeleteDraftParams = z.object({
+    inboxId: InboxIdSchema,
+    draftId: DraftIdSchema,
 })

--- a/node/src/schemas.ts
+++ b/node/src/schemas.ts
@@ -89,7 +89,7 @@ export const CreateDraftParams = z.object({
     html: z.string().optional().describe('HTML body'),
     replyTo: z.array(z.string()).optional().describe('Reply-to addresses'),
     inReplyTo: z.string().optional().describe('Message ID this draft is replying to'),
-    sendAt: z.string().optional().describe('ISO 8601 datetime to schedule sending (e.g. 2026-04-01T09:00:00Z)'),
+    sendAt: z.string().pipe(z.coerce.date()).optional().describe('ISO 8601 datetime to schedule sending (e.g. 2026-04-01T09:00:00Z)'),
     labels: z.array(z.string()).optional().describe('Labels'),
 })
 
@@ -110,7 +110,7 @@ export const UpdateDraftParams = z.object({
     text: z.string().optional().describe('Plain text body'),
     html: z.string().optional().describe('HTML body'),
     replyTo: z.array(z.string()).optional().describe('Reply-to addresses'),
-    sendAt: z.string().optional().describe('ISO 8601 datetime to reschedule sending'),
+    sendAt: z.string().pipe(z.coerce.date()).optional().describe('ISO 8601 datetime to reschedule sending'),
 })
 
 export const SendDraftParams = z.object({

--- a/node/src/tools.ts
+++ b/node/src/tools.ts
@@ -13,6 +13,12 @@ import {
     ReplyToMessageParams,
     UpdateMessageParams,
     ForwardMessageParams,
+    CreateDraftParams,
+    ListDraftsParams,
+    GetDraftParams,
+    UpdateDraftParams,
+    SendDraftParams,
+    DeleteDraftParams,
 } from './schemas.js'
 import {
     type Args,
@@ -27,6 +33,12 @@ import {
     replyToMessage,
     updateMessage,
     forwardMessage,
+    createDraft,
+    listDrafts,
+    getDraft,
+    updateDraft,
+    sendDraft,
+    deleteDraft,
 } from './functions.js'
 export interface Tool {
     name: string
@@ -155,6 +167,74 @@ export const tools: Tool[] = [
         annotations: {
             readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+        },
+    },
+    {
+        name: 'create_draft',
+        description: 'Create a draft email. Use send_at (ISO 8601 datetime) to schedule it for later sending.',
+        paramsSchema: CreateDraftParams,
+        func: createDraft,
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+            openWorldHint: false,
+        },
+    },
+    {
+        name: 'list_drafts',
+        description: 'List drafts in inbox. Filter by labels (e.g. "scheduled") to find scheduled drafts.',
+        paramsSchema: ListDraftsParams,
+        func: listDrafts,
+        annotations: {
+            readOnlyHint: true,
+            openWorldHint: false,
+        },
+    },
+    {
+        name: 'get_draft',
+        description: 'Get draft',
+        paramsSchema: GetDraftParams,
+        func: getDraft,
+        annotations: {
+            readOnlyHint: true,
+            openWorldHint: false,
+        },
+    },
+    {
+        name: 'update_draft',
+        description: 'Update a draft. Use send_at to reschedule a scheduled draft.',
+        paramsSchema: UpdateDraftParams,
+        func: updateDraft,
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+        },
+    },
+    {
+        name: 'send_draft',
+        description: 'Send a draft immediately. The draft is converted to a sent message and deleted.',
+        paramsSchema: SendDraftParams,
+        func: sendDraft,
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+            openWorldHint: true,
+        },
+    },
+    {
+        name: 'delete_draft',
+        description: 'Delete a draft. Also used to cancel a scheduled send.',
+        paramsSchema: DeleteDraftParams,
+        func: deleteDraft,
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
             idempotentHint: true,
             openWorldHint: false,
         },

--- a/node/src/tools.ts
+++ b/node/src/tools.ts
@@ -195,7 +195,7 @@ export const tools: Tool[] = [
     },
     {
         name: 'get_draft',
-        description: 'Get draft',
+        description: 'Get a draft by ID, including its content, status, and scheduled send time.',
         paramsSchema: GetDraftParams,
         func: getDraft,
         annotations: {


### PR DESCRIPTION
Add six tools for drafts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full draft email support to the Node toolkit: create, list, get, update, send, and delete drafts, including scheduling and cancellation.

- **New Features**
  - Tools: create_draft, list_drafts, get_draft, update_draft, send_draft, delete_draft.
  - Scheduling via sendAt (ISO 8601 string coerced to JS Date); delete_draft cancels scheduled sends; list_drafts can filter by labels like "scheduled".
  - Added draft schemas and functions; integrated into the tool registry with safety annotations.

<sup>Written for commit 933ea0b50d4ec5f846340a42c9ce23c5ebff90c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

