### PR TITLE
fix(mcp): return 'OK' when tool result is undefined

### DIFF
--- a/node/src/mcp.ts
+++ b/node/src/mcp.ts
@@ -29,8 +29,9 @@ export class AgentMailToolkit extends ListToolkit<McpTool> {
             inputSchema: tool.paramsSchema.shape,
             callback: async (args) => {
                 const { isError, result } = await safeFunc(tool.func, this.client, args)
+                const text = result === undefined ? 'OK' : JSON.stringify(result, null, 2)
                 return {
-                    content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+                    content: [{ type: 'text' as const, text }],
                     isError,
                 }
             },


### PR DESCRIPTION
## Summary

`delete_inbox` and `delete_draft` (and any other tool whose underlying SDK call returns `void`) currently fail in MCP clients with:

```
-32602 Invalid tools/call result: ... expected string, received undefined
```

## Why

The AgentMail SDK delete methods return `HttpResponsePromise<void>` because the API responds 204 No Content. `JSON.stringify(undefined)` evaluates to the JS `undefined` value (not the string `"undefined"`), which violates the MCP `CallToolResult` schema requiring `text` to be a string.

## Fix

Coerce undefined results to the literal string `"OK"` before serializing. All other (defined) results pass through `JSON.stringify` unchanged, so existing tools are unaffected.

```ts
const text = result === undefined ? 'OK' : JSON.stringify(result, null, 2)
return {
    content: [{ type: 'text' as const, text }],
    isError,
}
```

## Test plan

- [x] Local repro: `delete_inbox` and `delete_draft` no longer return the `-32602` schema error
- [x] Validated against `@modelcontextprotocol/sdk` `CallToolResultSchema` with a script mocking `AgentMailClient`
- [ ] Reviewer: confirm no regression for tools that return objects (e.g. `list_inboxes`, `send_message`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return "OK" when an MCP tool result is undefined, so delete operations like `delete_inbox` and `delete_draft` no longer fail with -32602 and the CallToolResult text is always a string. Other results still use JSON.stringify unchanged.

<sup>Written for commit 2fc9f4657d095f9536366122d426411fbc19d0f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

