### PR TITLE
fix(langchain): annotate args type to unblock dts build

### DIFF
--- a/node/src/langchain.ts
+++ b/node/src/langchain.ts
@@ -6,7 +6,7 @@ import { safeFunc } from './util.js'
 
 export class AgentMailToolkit extends ListToolkit<StructuredTool> {
     protected buildTool(tool: Tool): StructuredTool {
-        return langchainTool(async (args) => JSON.stringify((await safeFunc(tool.func, this.client, args)).result, null, 2), {
+        return langchainTool(async (args: Record<string, any>) => JSON.stringify((await safeFunc(tool.func, this.client, args)).result, null, 2), {
             name: tool.name,
             description: tool.description,
             schema: tool.paramsSchema,


### PR DESCRIPTION
`langchainTool` infers the callback's `args` parameter as `unknown` when the schema is a generic Zod schema, which then fails to satisfy `safeFunc`'s `Record<string, any>` constraint and breaks `tsup --dts`:

  src/langchain.ts(9,101): error TS2345: Argument of type 'unknown'
  is not assignable to parameter of type 'Record<string, any>'.

Annotate the parameter explicitly. Runtime behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Annotate the `args` parameter as `Record<string, any>` in the `langchainTool` callback to satisfy `safeFunc` and fix the `tsup --dts` build error. This addresses a type inference issue where a generic Zod schema produced `unknown`; runtime behavior is unchanged.

<sup>Written for commit 35626a5db5352d46b47d135065ccb4189ed7714b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

