### PR TITLE
docs: enhance README with framework matrix, comparison table, and quick start examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,112 @@
 # AgentMail Toolkit
 
-The AgentMail Toolkit integrates popular agent frameworks and protocols including OpenAI Agents SDK, Vercel AI SDK, and Model Context Protocol (MCP) with the AgentMail API.
+[![PyPI](https://img.shields.io/pypi/v/agentmail-toolkit)](https://pypi.org/project/agentmail-toolkit/)
+[![npm](https://img.shields.io/npm/v/agentmail-toolkit)](https://www.npmjs.com/package/agentmail-toolkit)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-## Setup & Usage
+**Give any AI agent its own email inbox.** The AgentMail Toolkit provides pre-built integrations for popular agent frameworks — so your agent can send, receive, read, and reply to real emails in minutes.
 
-See the [Python](/python) and [Node](/node) packages for language specific setup and usage.
+🔗 **[agentmail.to](https://agentmail.to)** · 📖 **[Docs](https://docs.agentmail.to)** · 💬 **[Discord](https://discord.gg/ZYN7f7KPjS)**
+
+## Supported Frameworks
+
+| Framework | Python | Node/TypeScript |
+|---|---|---|
+| [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | ✅ | — |
+| [Vercel AI SDK](https://github.com/vercel/ai) | — | ✅ |
+| [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) | ✅ | ✅ |
+
+> Looking for the core SDK? See [agentmail-python](https://github.com/agentmail-to/agentmail-python) or [agentmail-node](https://github.com/agentmail-to/agentmail-node).
+
+## Quick Start
+
+### Python (OpenAI Agents SDK)
+
+```bash
+pip install agentmail-toolkit
+export AGENTMAIL_API_KEY=your-api-key
+```
+
+```python
+from agentmail_toolkit.openai import AgentMailToolkit
+from agents import Agent, Runner
+
+agent = Agent(
+    name="Email Agent",
+    instructions="You are an agent that can send, receive, and manage emails.",
+    tools=AgentMailToolkit().get_tools(),
+)
+
+result = Runner.run_sync(agent, "Create a new inbox and send a hello email to test@example.com")
+print(result.final_output)
+```
+
+### TypeScript (Vercel AI SDK)
+
+```bash
+npm install agentmail-toolkit
+export AGENTMAIL_API_KEY=your-api-key
+```
+
+```typescript
+import { openai } from '@ai-sdk/openai'
+import { AgentMailToolkit } from 'agentmail-toolkit/ai-sdk'
+import { streamText } from 'ai'
+
+const result = streamText({
+    model: openai('gpt-4o'),
+    messages,
+    system: 'You are an email agent that can create and manage inboxes, send, and receive emails.',
+    tools: new AgentMailToolkit().getTools(),
+})
+```
+
+## What Can Your Agent Do?
+
+With the AgentMail Toolkit, your agent gets tools to:
+
+- 📬 **Create inboxes** — Spin up email addresses on-demand, programmatically
+- 📤 **Send emails** — Compose and send emails with attachments
+- 📥 **Receive & read emails** — Poll or get webhooks for incoming mail
+- 🔍 **Search emails** — Semantic search across inbox contents
+- 🧵 **Manage threads** — Follow and reply to email conversations
+- 📎 **Handle attachments** — Extract text from PDFs, images, and documents
+
+## Why AgentMail vs Gmail API / SendGrid / Resend?
+
+| Feature | AgentMail | Gmail API | SendGrid | Resend |
+|---|---|---|---|---|
+| Programmatic inbox creation | ✅ | ❌ | ❌ | ❌ |
+| Two-way email (send + receive) | ✅ | ✅ | Inbound parse only | ❌ |
+| Agent framework integrations | ✅ | ❌ | ❌ | ❌ |
+| Semantic search | ✅ | ❌ | ❌ | ❌ |
+| No OAuth per inbox | ✅ | ❌ | ✅ | ✅ |
+| Webhooks + WebSockets | ✅ | Push only | Webhooks | Webhooks |
+| Usage-based pricing | ✅ | Per-seat | Per-email | Per-email |
+
+## Examples
+
+Check out [agentmail-examples](https://github.com/agentmail-to/agentmail-examples) for production-ready templates:
+
+- **[Email Agent](https://github.com/agentmail-to/agentmail-examples/tree/main/email-agent)** — Autonomous email responder
+- **[Sales Agent](https://github.com/agentmail-to/agentmail-examples/tree/main/sales-agent)** — Outbound sales via email
+- **[Support Agent](https://github.com/agentmail-to/agentmail-examples/tree/main/support-agent)** — Auto-respond to support tickets
+- **[Invoice Processor](https://github.com/agentmail-to/agentmail-examples/tree/main/invoice-processor)** — Extract and process invoices with Claude vision
+- **[Newsletter Digest](https://github.com/agentmail-to/agentmail-examples/tree/main/newsletter-digest)** — Summarize newsletters into a morning digest
+
+## Package Documentation
+
+- **[Python package →](./python)** — OpenAI Agents SDK + MCP integration
+- **[Node package →](./node)** — Vercel AI SDK + MCP integration
+
+## Links
+
+- [AgentMail](https://agentmail.to) — The email API for AI agents (YC S25)
+- [Documentation](https://docs.agentmail.to)
+- [Python SDK](https://github.com/agentmail-to/agentmail-python) · [npm SDK](https://github.com/agentmail-to/agentmail-node)
+- [MCP Server](https://github.com/agentmail-to/agentmail-mcp)
+- [CLI](https://github.com/agentmail-to/agentmail-cli)
+
+## License
+
+MIT


### PR DESCRIPTION
## What this PR does

Transforms the README from a 7-line stub into a comprehensive, SEO-optimized landing page for the toolkit.

### Changes:
- **Badges** — PyPI, npm, and license badges for credibility signals
- **Framework matrix** — Clear table showing OpenAI Agents SDK, Vercel AI SDK, and MCP support per language
- **Quick start examples** — Copy-paste code for both Python and TypeScript
- **Capabilities section** — What agents can do with the toolkit (create inboxes, send/receive, semantic search, etc.)
- **Comparison table** — AgentMail vs Gmail API vs SendGrid vs Resend feature matrix
- **Examples links** — Direct links to the best templates in agentmail-examples
- **Links section** — All ecosystem repos linked

### Why this matters:
This is the highest-star repo (71★) in the org. The README is the first thing developers see. A rich README:
1. Increases GitHub search ranking (more keyword matches)
2. Converts visitors into users (clear value prop + copy-paste examples)
3. Captures comparison search intent ('agentmail vs resend', 'email api for agents')
4. Shows framework compatibility at a glance

### SEO keywords captured:
- AI agent email
- email inbox API
- OpenAI Agents SDK email
- Vercel AI SDK email
- MCP email server
- agent framework email integration