### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: cd python && uv sync --frozen
+      - name: Run tests
+        run: cd python && uv run pytest


### PR DESCRIPTION
## Summary
Adds CI workflow.
## Testing
CI passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions CI workflow that installs Python dependencies with `uv` and runs `pytest` on pushes and pull requests to `main`. Uses `astral-sh/setup-uv@v4` with caching and `uv sync --frozen` for reproducible installs.

<sup>Written for commit 3c3948b1cb7ae917fc31e0fddf0226fe34eddbe7. Summary will update on new commits. <a href="https://cubic.dev/pr/agentmail-to/agentmail-toolkit/pull/26?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

