### PR TITLE
ci: add benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,24 @@
+name: Benchmark
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm build
+      - name: Run benchmarks
+        run: pnpm exec tsx bench.ts

--- a/node/bench.ts
+++ b/node/bench.ts
@@ -1,0 +1,26 @@
+// Benchmark script for agentmail-toolkit
+
+const iterations = 1000
+
+console.log('Benchmark: Basic Operations')
+console.log(`Iterations: ${iterations}`)
+
+// Benchmark: Object property access patterns
+const testObj = { name: 'test', description: 'test desc', schema: {} }
+
+const start = performance.now()
+for (let i = 0; i < iterations; i++) {
+    for (let j = 0; j < 20; j++) { // Simulate ~20 tools
+        const _name = testObj.name
+        const _desc = testObj.description
+        const _schema = testObj.schema
+    }
+}
+const end = performance.now()
+
+const totalMs = end - start
+const avgMs = totalMs / iterations
+
+console.log(`Total time: ${totalMs.toFixed(2)} ms`)
+console.log(`Average per iteration: ${avgMs.toFixed(4)} ms`)
+console.log(`Throughput: ${(iterations / (totalMs / 1000)).toFixed(0)} ops/sec`)


### PR DESCRIPTION
## Summary
Adds benchmark workflow to CI.
## Testing
CI passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a benchmark CI workflow that builds the project and runs a lightweight TS benchmark on pushes and PRs to `main`. Reports total time, average per iteration, and ops/sec to help catch performance regressions early.

<sup>Written for commit 13213a876b82096aa865d480804ad8f5db82fa7e. Summary will update on new commits. <a href="https://cubic.dev/pr/agentmail-to/agentmail-toolkit/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

