### PR TITLE
docs: readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ The AgentMail Toolkit integrates popular agent frameworks and protocols includin
 ## Setup & Usage
 
 See the [Python](/python) and [Node](/node) packages for language specific setup and usage.
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a missing trailing newline to `README.md` to fix minor Markdown formatting and clear linter warnings.

<sup>Written for commit 9a4b2a9d4187fd716e5679438687a9c9fbcdee88. Summary will update on new commits. <a href="https://cubic.dev/pr/agentmail-to/agentmail-toolkit/pull/30?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

