### PR TITLE
fix(livekit): use asyncio.to_thread so status-update task actually runs

### DIFF
--- a/python/src/agentmail_toolkit/livekit.py
+++ b/python/src/agentmail_toolkit/livekit.py
@@ -22,7 +22,11 @@ class AgentMailToolkit(Toolkit[FunctionTool]):
 
                 status_update_task = asyncio.create_task(_status_update())
 
-                result = tool.func(self.client, raw_arguments).model_dump_json()
+                # Run the synchronous HTTP call in a thread pool so the event
+                # loop stays free and _status_update can actually execute.
+                result = await asyncio.to_thread(
+                    lambda: tool.func(self.client, raw_arguments).model_dump_json()
+                )
 
                 status_update_task.cancel()
 

--- a/python/tests/test_livekit_status_update.py
+++ b/python/tests/test_livekit_status_update.py
@@ -1,0 +1,175 @@
+"""Tests that the LiveKit tool's status-update task actually runs.
+
+Before the fix, `tool.func` was called synchronously inside the async `f`
+handler.  Because a synchronous (blocking) call never yields to the event
+loop, the `_status_update` task created just before it could never be
+scheduled — and was cancelled before it had a chance to run.
+
+After the fix, `tool.func` is off-loaded to a thread via `asyncio.to_thread`,
+which yields control back to the event loop and lets `_status_update` run.
+"""
+
+import asyncio
+import threading
+import unittest
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs for livekit.agents and agentmail so the import works in
+# environments that don't have those packages installed.
+# ---------------------------------------------------------------------------
+
+import sys
+import types
+
+# Stub heavy optional dependencies before any agentmail_toolkit import
+for _mod in [
+    "livekit",
+    "livekit.agents",
+    "pymupdf",
+    "filetype",
+    "docx",
+    "langchain",
+    "langchain.tools",
+    "agents",
+]:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+livekit_agents = sys.modules["livekit.agents"]
+livekit_agents.FunctionTool = object  # type: ignore[attr-defined]
+livekit_agents.RunContext = object  # type: ignore[attr-defined]
+livekit_agents.ToolError = Exception  # type: ignore[attr-defined]
+
+
+def _noop_function_tool(**kwargs):
+    """Stub for livekit.agents.function_tool — just return a sentinel."""
+    func = kwargs.get("f")
+
+    class _FakeFunctionTool:
+        def __init__(self):
+            self._f = func
+
+        async def __call__(self, *args, **kw):
+            return await self._f(*args, **kw)
+
+    return _FakeFunctionTool()
+
+
+livekit_agents.function_tool = _noop_function_tool  # type: ignore[attr-defined]
+
+if "agentmail" not in sys.modules:
+    sys.modules["agentmail"] = types.ModuleType("agentmail")
+    sys.modules["agentmail"].AgentMail = MagicMock  # type: ignore[attr-defined]
+
+# Patch the toolkit base so we don't try to build all tools at init time.
+from agentmail_toolkit.tools import Tool  # noqa: E402
+from agentmail_toolkit.livekit import AgentMailToolkit  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool(func) -> Tool:
+    """Build a minimal Tool wrapping the given callable."""
+    from pydantic import BaseModel
+
+    class _Params(BaseModel):
+        pass
+
+    return Tool(
+        name="test_tool",
+        description="test description",
+        params_schema=_Params,
+        func=func,
+    )
+
+
+def _make_context(reply_mock: AsyncMock) -> MagicMock:
+    ctx = MagicMock()
+    ctx.session.generate_reply = reply_mock
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLiveKitStatusUpdateRuns(unittest.IsolatedAsyncioTestCase):
+    """Verify that _status_update is given a chance to run during tool execution."""
+
+    async def test_status_update_fires_during_blocking_tool(self) -> None:
+        """_status_update must run before tool.func returns.
+
+        If tool.func blocks the event loop (old code), _status_update is
+        cancelled before it can be scheduled and `generate_reply` is never
+        called.  With asyncio.to_thread, the task runs concurrently.
+        """
+        reply_called = asyncio.Event()
+
+        async def mock_generate_reply(**kwargs):
+            reply_called.set()
+
+        reply_mock = AsyncMock(side_effect=mock_generate_reply)
+        ctx = _make_context(reply_mock)
+
+        # Synchronous tool that deliberately yields by sleeping in a thread —
+        # we wait until status_update has a chance to fire, then proceed.
+        gate = threading.Event()
+
+        def slow_func(client, kwargs):
+            # Block just long enough for the event loop to schedule tasks.
+            gate.wait(timeout=2)
+            result = MagicMock()
+            result.model_dump_json.return_value = '{"ok": true}'
+            return result
+
+        tool = _make_tool(slow_func)
+
+        toolkit = object.__new__(AgentMailToolkit)
+        toolkit.client = MagicMock()
+        built = toolkit._build_tool(tool)
+
+        # Schedule the tool call.  We allow _status_update to run by releasing
+        # the gate only after the event loop gets control back.
+        async def run():
+            task = asyncio.create_task(built._f({}, ctx))
+            # Let the event loop tick once so _status_update can start.
+            await asyncio.sleep(0)
+            gate.set()  # Release slow_func
+            return await task
+
+        await run()
+        self.assertTrue(
+            reply_called.is_set(),
+            "generate_reply was never called — status update did not run",
+        )
+
+    async def test_tool_result_returned_correctly(self) -> None:
+        """The tool result must be the JSON-serialised return value of func."""
+        reply_mock = AsyncMock()
+        ctx = _make_context(reply_mock)
+
+        expected = '{"message": "hello"}'
+
+        def func(client, kwargs):
+            result = MagicMock()
+            result.model_dump_json.return_value = expected
+            return result
+
+        tool = _make_tool(func)
+        toolkit = object.__new__(AgentMailToolkit)
+        toolkit.client = MagicMock()
+        built = toolkit._build_tool(tool)
+
+        result = await built._f({}, ctx)
+        self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The LiveKit tool handler is intended to display a status message to the user
while the underlying AgentMail API call is in flight:

```python
status_update_task = asyncio.create_task(_status_update())

result = tool.func(self.client, raw_arguments).model_dump_json()  # sync HTTP

status_update_task.cancel()
```

`tool.func` calls the synchronous `AgentMail` client, which uses `httpx.Client`
and blocks the calling thread.  In an async context that means the **event
loop is blocked** for the entire duration of the HTTP request.  Because the
event loop cannot run other tasks while it is blocked, `_status_update` is
never scheduled.  When `tool.func` finally returns, the very next line cancels
the task — so `generate_reply` is **never called** and the user never sees the
status update.

## Fix

Off-load `tool.func` to a thread pool with `asyncio.to_thread`.  The event
loop stays free while the HTTP call runs in a worker thread, giving
`_status_update` the time slice it needs to run:

```python
# before
result = tool.func(self.client, raw_arguments).model_dump_json()

# after
result = await asyncio.to_thread(
    lambda: tool.func(self.client, raw_arguments).model_dump_json()
)
```

## Tests

`python/tests/test_livekit_status_update.py` (both pass):

- `test_status_update_fires_during_blocking_tool` — a slow sync tool is used; after releasing the gate the test verifies `generate_reply` was called
- `test_tool_result_returned_correctly` — the JSON result is still returned correctly after the change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the synchronous `AgentMail` HTTP call in a thread so the LiveKit tool handler doesn’t block the event loop. This lets the status-update task run and show progress while the tool executes.

- **Bug Fixes**
  - Use `asyncio.to_thread` for `tool.func(...).model_dump_json()` so `_status_update` can execute and call `generate_reply`.
  - Add tests to verify the status update fires during a slow sync tool and the JSON result is returned unchanged.

<sup>Written for commit 0387c086c373da9d39dfeb2df5144d7a058850e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agentmail-to/agentmail-toolkit/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

