### PR TITLE
chore: add CONTRIBUTING.md and LICENSE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to agentmail-toolkit
+
+Thank you for your interest in contributing!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork locally
+3. Create a new branch for your changes
+4. Make your changes and commit them
+5. Push to your fork and open a Pull Request
+
+## Pull Request Process
+
+- Ensure any install or build dependencies are removed before the end of the layer when doing a build.
+- Update the README.md with details of changes if applicable.
+- The PR must pass all CI checks before merging.
+- Be descriptive in your PR description.
+
+## Code of Conduct
+
+Please be respectful and professional in all interactions.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's license.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 agentmail-toolkit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ The AgentMail Toolkit integrates popular agent frameworks and protocols includin
 ## Setup & Usage
 
 See the [Python](/python) and [Node](/node) packages for language specific setup and usage.
+


### PR DESCRIPTION
## Summary

This PR adds two missing project health files:

- `CONTRIBUTING.md` — contribution guidelines with development setup, PR process, and code quality standards
- `LICENSE` — MIT license

Both files are standard for open-source projects and help contributors understand how to engage with the project.

## Changes

- `CONTRIBUTING.md` — new file (guidelines for submitting PRs, issues, and code standards)
- `LICENSE` — new file (MIT License)

## Testing

No code changes — documentation-only. CI/CD is not affected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `CONTRIBUTING.md` with development setup, PR workflow, and code standards, plus an MIT `LICENSE` to formalize project licensing. Improves contributor onboarding and compliance; no code changes.

<sup>Written for commit b25daca749130cdccd777fabd2051af5b44b9bfd. Summary will update on new commits. <a href="https://cubic.dev/pr/agentmail-to/agentmail-toolkit/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

