### PR TITLE
fix(schemas): give optional tool params a None default

### DIFF
--- a/python/src/agentmail_toolkit/schemas.py
+++ b/python/src/agentmail_toolkit/schemas.py
@@ -12,7 +12,7 @@ class ListItemsParams(BaseModel):
     limit: Optional[int] = Field(
         default=10, description="Max number of items to return"
     )
-    page_token: Optional[str] = Field(description="Pagination page token")
+    page_token: Optional[str] = Field(default=None, description="Pagination page token")
 
 
 class GetInboxParams(BaseModel):
@@ -20,16 +20,16 @@ class GetInboxParams(BaseModel):
 
 
 class CreateInboxParams(BaseModel):
-    username: Optional[str] = Field(description="Username")
-    domain: Optional[str] = Field(description="Domain")
-    display_name: Optional[str] = Field(description="Display name")
+    username: Optional[str] = Field(default=None, description="Username")
+    domain: Optional[str] = Field(default=None, description="Domain")
+    display_name: Optional[str] = Field(default=None, description="Display name")
 
 
 class ListInboxItemsParams(ListItemsParams):
     inbox_id: InboxIdField
-    labels: Optional[List[str]] = Field(description="Filter items with labels")
-    before: Optional[datetime] = Field(description="Filter items before datetime")
-    after: Optional[datetime] = Field(description="Filter items after datetime")
+    labels: Optional[List[str]] = Field(default=None, description="Filter items with labels")
+    before: Optional[datetime] = Field(default=None, description="Filter items before datetime")
+    after: Optional[datetime] = Field(default=None, description="Filter items after datetime")
 
 
 class GetThreadParams(BaseModel):
@@ -52,22 +52,22 @@ class Attachment(BaseModel):
 
 class BaseMessageParams(BaseModel):
     inbox_id: InboxIdField
-    text: Optional[str] = Field(description="Plain text body")
-    html: Optional[str] = Field(description="HTML body")
-    labels: Optional[List[str]] = Field(description="Labels")
+    text: Optional[str] = Field(default=None, description="Plain text body")
+    html: Optional[str] = Field(default=None, description="HTML body")
+    labels: Optional[List[str]] = Field(default=None, description="Labels")
     attachments: Optional[List[Attachment]] = Field(default=None, description="Attachments")
 
 
 class SendMessageParams(BaseMessageParams):
     to: List[str] = Field(description="Recipients")
-    cc: Optional[List[str]] = Field(description="CC recipients")
-    bcc: Optional[List[str]] = Field(description="BCC recipients")
-    subject: Optional[str] = Field(description="Subject")
+    cc: Optional[List[str]] = Field(default=None, description="CC recipients")
+    bcc: Optional[List[str]] = Field(default=None, description="BCC recipients")
+    subject: Optional[str] = Field(default=None, description="Subject")
 
 
 class ReplyToMessageParams(BaseMessageParams):
     message_id: MessageIdField
-    reply_all: Optional[bool] = Field(description="Reply to all recipients")
+    reply_all: Optional[bool] = Field(default=None, description="Reply to all recipients")
 
 
 class ForwardMessageParams(SendMessageParams):
@@ -77,5 +77,5 @@ class ForwardMessageParams(SendMessageParams):
 class UpdateMessageParams(BaseModel):
     inbox_id: InboxIdField
     message_id: MessageIdField
-    add_labels: Optional[List[str]] = Field(description="Labels to add")
-    remove_labels: Optional[List[str]] = Field(description="Labels to remove")
+    add_labels: Optional[List[str]] = Field(default=None, description="Labels to add")
+    remove_labels: Optional[List[str]] = Field(default=None, description="Labels to remove")

--- a/python/tests/test_schemas_optional_defaults.py
+++ b/python/tests/test_schemas_optional_defaults.py
@@ -1,0 +1,15 @@
+from agentmail_toolkit.schemas import CreateInboxParams, ListItemsParams
+
+
+def test_create_inbox_params_allows_empty():
+    # SDK's inboxes.create() accepts no arguments (random inbox);
+    # the tool schema must not require username/domain/display_name.
+    params = CreateInboxParams()
+    assert params.username is None
+    assert params.domain is None
+    assert params.display_name is None
+
+
+def test_list_items_params_allows_only_limit():
+    params = ListItemsParams(limit=5)
+    assert params.page_token is None


### PR DESCRIPTION
## What's broken

Every optional field in the toolkit's parameter schemas is declared as `Optional[...] = Field(description=...)` with no default. In Pydantic v2 an `Optional` field without a default is still required, so the tools mark fields the API treats as optional as mandatory. Calling `create_inbox` with no arguments — the documented way to get a random inbox — raises before any request is made:

```
pydantic_core._pydantic_core.ValidationError: 3 validation errors for CreateInboxParams
username  Field required [type=missing, ...]
domain    Field required [type=missing, ...]
display_name  Field required [type=missing, ...]
```

The same defect breaks minimal calls to list/send/reply/forward/update.

## Why it happens

In Pydantic v2, `Optional[X] = Field(...)` without `default=` is a required field.

## Fix

Add `default=None` to the optional fields that were missing it.

## Test

`CreateInboxParams()` and `ListItemsParams(limit=5)` now construct without error; both raised `ValidationError` before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set default=None on all optional params in the toolkit schemas to match `pydantic` v2 behavior. This prevents ValidationError crashes on minimal calls like `create_inbox()` with no args.

- **Bug Fixes**
  - Set `default=None` for all Optional fields across parameter models so optional inputs are truly optional.
  - Added tests confirming `CreateInboxParams()` and `ListItemsParams(limit=5)` instantiate without errors and keep `page_token=None`.

<sup>Written for commit 715ae78ea08e8f0e7c6c857d76f47384dd7289e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agentmail-to/agentmail-toolkit/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

