### PR TITLE
Align MCP tool annotations and descriptions with Anthropic directory review criteria

### DIFF
--- a/node/src/mcp.ts
+++ b/node/src/mcp.ts
@@ -29,7 +29,7 @@ export class AgentMailToolkit extends ListToolkit<McpTool> {
             inputSchema: tool.paramsSchema.shape,
             callback: async (args) => {
                 const { isError, result } = await safeFunc(tool.func, this.client, args)
-                const text = result === undefined ? 'OK' : JSON.stringify(result, null, 2)
+                const text = result === undefined ? 'OK' : JSON.stringify(result)
                 return {
                     content: [{ type: 'text' as const, text }],
                     isError,

--- a/node/src/tools.ts
+++ b/node/src/tools.ts
@@ -51,7 +51,7 @@ export interface Tool {
 export const tools: Tool[] = [
     {
         name: 'list_inboxes',
-        description: 'List inboxes',
+        description: 'List email inboxes, paginated.',
         paramsSchema: ListItemsParams,
         func: listInboxes,
         annotations: {
@@ -61,7 +61,7 @@ export const tools: Tool[] = [
     },
     {
         name: 'get_inbox',
-        description: 'Get inbox',
+        description: 'Get an inbox by ID.',
         paramsSchema: GetInboxParams,
         func: getInbox,
         annotations: {
@@ -71,7 +71,7 @@ export const tools: Tool[] = [
     },
     {
         name: 'create_inbox',
-        description: 'Create inbox',
+        description: 'Create a new email inbox. Optionally specify username, domain, and display name.',
         paramsSchema: CreateInboxParams,
         func: createInbox,
         annotations: {
@@ -83,7 +83,7 @@ export const tools: Tool[] = [
     },
     {
         name: 'delete_inbox',
-        description: 'Delete inbox',
+        description: 'Delete an inbox by ID.',
         paramsSchema: GetInboxParams,
         func: deleteInbox,
         annotations: {
@@ -95,7 +95,7 @@ export const tools: Tool[] = [
     },
     {
         name: 'list_threads',
-        description: 'List threads in inbox',
+        description: 'List email threads in an inbox. Filter by labels or before/after datetime, paginated.',
         paramsSchema: ListInboxItemsParams,
         func: listThreads,
         annotations: {
@@ -105,7 +105,7 @@ export const tools: Tool[] = [
     },
     {
         name: 'get_thread',
-        description: 'Get thread',
+        description: 'Get a thread by ID, including its messages.',
         paramsSchema: GetThreadParams,
         func: getThread,
         annotations: {
@@ -115,7 +115,7 @@ export const tools: Tool[] = [
     },
     {
         name: 'get_attachment',
-        description: 'Get attachment',
+        description: 'Get an attachment from a thread. Returns metadata and a download URL, plus extracted text for PDF and DOCX files.',
         paramsSchema: GetAttachmentParams,
         func: getAttachment,
         annotations: {
@@ -125,55 +125,55 @@ export const tools: Tool[] = [
     },
     {
         name: 'send_message',
-        description: 'Send message',
+        description: 'Send an email from an inbox to one or more recipients.',
         paramsSchema: SendMessageParams,
         func: sendMessage,
         annotations: {
             readOnlyHint: false,
-            destructiveHint: false,
+            destructiveHint: true,
             idempotentHint: false,
             openWorldHint: true,
         },
     },
     {
         name: 'reply_to_message',
-        description: 'Reply to message',
+        description: 'Reply to a message in its thread. Set replyAll to include all original recipients.',
         paramsSchema: ReplyToMessageParams,
         func: replyToMessage,
         annotations: {
             readOnlyHint: false,
-            destructiveHint: false,
+            destructiveHint: true,
             idempotentHint: false,
             openWorldHint: true,
         },
     },
     {
         name: 'forward_message',
-        description: 'Forward message',
+        description: 'Forward a message to new recipients.',
         paramsSchema: ForwardMessageParams,
         func: forwardMessage,
         annotations: {
             readOnlyHint: false,
-            destructiveHint: false,
+            destructiveHint: true,
             idempotentHint: false,
             openWorldHint: true,
         },
     },
     {
         name: 'update_message',
-        description: 'Update message',
+        description: "Update a message's labels (add or remove).",
         paramsSchema: UpdateMessageParams,
         func: updateMessage,
         annotations: {
             readOnlyHint: false,
-            destructiveHint: false,
+            destructiveHint: true,
             idempotentHint: true,
             openWorldHint: false,
         },
     },
     {
         name: 'create_draft',
-        description: 'Create a draft email. Use send_at (ISO 8601 datetime) to schedule it for later sending.',
+        description: 'Create a draft email. Use sendAt (ISO 8601 datetime) to schedule it for later sending.',
         paramsSchema: CreateDraftParams,
         func: createDraft,
         annotations: {
@@ -205,12 +205,12 @@ export const tools: Tool[] = [
     },
     {
         name: 'update_draft',
-        description: 'Update a draft. Use send_at to reschedule a scheduled draft.',
+        description: 'Update a draft. Use sendAt to reschedule a scheduled draft.',
         paramsSchema: UpdateDraftParams,
         func: updateDraft,
         annotations: {
             readOnlyHint: false,
-            destructiveHint: false,
+            destructiveHint: true,
             idempotentHint: true,
             openWorldHint: false,
         },
@@ -222,7 +222,7 @@ export const tools: Tool[] = [
         func: sendDraft,
         annotations: {
             readOnlyHint: false,
-            destructiveHint: false,
+            destructiveHint: true,
             idempotentHint: false,
             openWorldHint: true,
         },


### PR DESCRIPTION
Prep for submitting the hosted MCP server (`mcp.agentmail.to/mcp`) to Anthropic's Connectors Directory. Their [review criteria](https://claude.com/docs/connectors/building/review-criteria) require every tool to carry a `title` plus `readOnlyHint: true` (read-only) or `destructiveHint: true` (modifies/deletes data), and descriptions that precisely match actual behavior — reviewers call every tool and verify.

## Annotation changes (`node/src/tools.ts`)

Set `destructiveHint: true` on:
- **`send_message`, `reply_to_message`, `forward_message`, `send_draft`** — irreversible, outward-facing action (email leaves the system). Claude uses these hints for auto-approval decisions; marking sends non-destructive is the most likely review flag.
- **`update_message`, `update_draft`** — modify existing data, which is the literal criterion.

`create_inbox` / `create_draft` stay `destructiveHint: false` (purely additive, reversible).

## Description fixes

- **Accuracy:** `create_draft`/`update_draft` referenced `send_at`, but the schema field is `sendAt`. `update_message` said "Update message" but only adds/removes labels (over-promise). `get_attachment` never mentioned it returns a download URL and extracted text for PDF/DOCX.
- **Quality:** expanded terse descriptions ("Send message", "Get inbox") to full sentences stating what each tool does, per the criteria's "state precisely what the tool does and when to invoke it".

All claims verified against the live hosted server (e.g. `get_thread` does include a `messages` array; `get_attachment` does return `downloadUrl` + extracted PDF text).

## Output formatting (`node/src/mcp.ts`)

Tool results now use compact `JSON.stringify(result)` instead of pretty-printed (`null, 2`) — the [Directory Policy](https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy) requires MCP servers to be "frugal with token usage". Drop this commit hunk if pretty-printing was intentional for some client.

## Notes

- No version bump included — cut a release however you normally do; the hosted server needs to pick this up before the directory submission.
- Python package untouched (no MCP surface there).
- `pnpm build` passes; the 97 `no-explicit-any` lint errors are pre-existing on `main` (verified identical count on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)