### PR TITLE
0.4.0

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agentmail-toolkit",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "AgentMail Toolkit",
     "scripts": {
         "build": "tsup",


### PR DESCRIPTION
Version bump for the API-parity release (#39). Merge, then an npm owner (tanishq / joseph / harry / agentmail-admin) runs `npm publish` from `node/` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)