### PR TITLE
Surface API error reason + log tool failures in MCP

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agentmail-toolkit",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "AgentMail Toolkit",
     "scripts": {
         "build": "tsup",

--- a/node/src/mcp.ts
+++ b/node/src/mcp.ts
@@ -28,7 +28,13 @@ export class AgentMailToolkit extends ListToolkit<McpTool> {
             description: tool.description,
             inputSchema: tool.paramsSchema.shape,
             callback: async (args) => {
-                const { isError, result } = await safeFunc(tool.func, this.client, args)
+                const { isError, result, statusCode, body } = await safeFunc(tool.func, this.client, args)
+                if (isError) {
+                    // Errors are returned as isError tool results (HTTP 200), so they never
+                    // reach the host's error logs on their own. Log here, at the real catch
+                    // site, so failures are actually observable.
+                    console.error('[agentmail-toolkit] tool error', { tool: tool.name, statusCode, body })
+                }
                 const text = result === undefined ? 'OK' : JSON.stringify(result)
                 return {
                     content: [{ type: 'text' as const, text }],

--- a/node/src/mcp.ts
+++ b/node/src/mcp.ts
@@ -33,7 +33,11 @@ export class AgentMailToolkit extends ListToolkit<McpTool> {
                     // Errors are returned as isError tool results (HTTP 200), so they never
                     // reach the host's error logs on their own. Log here, at the real catch
                     // site, so failures are actually observable.
-                    console.error('[agentmail-toolkit] tool error', { tool: tool.name, statusCode, body })
+                    console.error('[agentmail-toolkit] tool error', {
+                        tool: tool.name,
+                        statusCode,
+                        body: typeof body === 'string' ? body.slice(0, 500) : body,
+                    })
                 }
                 const text = result === undefined ? 'OK' : JSON.stringify(result)
                 return {

--- a/node/src/util.ts
+++ b/node/src/util.ts
@@ -1,17 +1,36 @@
-import { AgentMailClient } from 'agentmail'
+import { AgentMailClient, AgentMailError } from 'agentmail'
 import { getDocumentProxy, extractText } from 'unpdf'
 import JSZip from 'jszip'
+
+// Pull the API's own explanation out of the error body (e.g. "address already
+// taken") instead of returning the SDK's verbose multi-line "Status code / Body"
+// dump. Generic across every tool.
+function apiErrorMessage(error: AgentMailError): string {
+    const body = error.body as { message?: string; detail?: string; error?: string } | string | undefined
+    const detail =
+        typeof body === 'string' ? body : (body?.message ?? body?.detail ?? body?.error)
+    const base = detail ?? error.message
+    return error.statusCode ? `${base} (HTTP ${error.statusCode})` : base
+}
 
 export const safeFunc = async <T>(
     func: (client: AgentMailClient, args: Record<string, any>) => Promise<T>,
     client: AgentMailClient,
     args: Record<string, any>
-) => {
+): Promise<{ isError: boolean; result: T | string; statusCode?: number; body?: unknown }> => {
     try {
         return { isError: false, result: await func(client, args) }
     } catch (error) {
+        if (error instanceof AgentMailError) {
+            return {
+                isError: true,
+                result: apiErrorMessage(error),
+                statusCode: error.statusCode,
+                body: error.body,
+            }
+        }
         if (error instanceof Error) return { isError: true, result: error.message }
-        else return { isError: true, result: 'Unknown error' }
+        return { isError: true, result: 'Unknown error' }
     }
 }
 


### PR DESCRIPTION
safeFunc now detects AgentMailError, returns statusCode/body and a concise message pulled from the API's own error body (e.g. "address already taken") instead of the SDK's verbose multi-line dump. The MCP callback logs { tool, statusCode, body } at the real catch site, so failures are visible in host logs (they're returned as isError over HTTP 200 and otherwise never reach them). Bump 0.4.0 -> 0.4.1.