### PR TITLE
chore(node): bump version to 0.5.0

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agentmail-toolkit",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "description": "AgentMail Toolkit",
     "scripts": {
         "build": "tsup",


### PR DESCRIPTION
## What

One-line version bump: `node/package.json` `0.4.1` → `0.5.0`. No code changes.

## Why

Investigating a ChatGPT Apps directory submission for the hosted MCP server (`mcp.agentmail.to`), I found `main`'s `node/src/tools.ts` has diverged significantly from what's actually reached users — verified by extracting and diffing the real compiled npm tarball contents, not just comparing source:

| | Deployed (prod) | Published (npm, latest) | `main` (this repo) |
|---|---|---|---|
| Version | `agentmail-toolkit@0.4.0` | `0.4.2` (published today) | unreleased |
| Tool count | 17 | 17 | **24** |
| `send_message`/`reply_to_message`/`forward_message`/`send_draft` | `destructiveHint: false` | `destructiveHint: false` | **`destructiveHint: true`** |
| Descriptions | one-line stubs (`"Send message"`) | same stubs | full sentences |

The `destructiveHint: false` on send-type tools is the concerning one — those tools send email to arbitrary external recipients, and marking them non-destructive is exactly the "under-annotated write tool" pattern OpenAI's submission review flags as a common rejection cause. The correct, honest annotation already exists in this repo's source; it's just never shipped.

## Why minor, not patch

This repo's history shows informal patch bumps even for feature work (e.g. "add draft tools" as a patch), but 7 new tools plus a client-visible trust-signal change on 4 existing ones is a minor bump by any reasonable reading — and it makes the release legible when referenced later (e.g. in the OpenAI submission notes, or in the dependent `agentmail-manufact-mcp` repo's pin).

## One more thing worth flagging

`node/package.json`'s version field was itself stale — it said `0.4.1` even though `0.4.2` is the latest version actually on npm. That means whatever produced the `0.4.2` publish (earlier today) didn't come from a `main` commit that bumped this field first. Worth checking what happened there before repeating the pattern — I've noted it in the commit message as a heads-up for whoever runs the next publish.

## Scope note

Node package only (`node/package.json`). The Python package (`python/pyproject.toml`, currently `0.2.7`) is independently versioned and untouched — separate implementation, not part of this MCP surface.

## Not done here (deliberately)

This PR does **not** run `npm publish`. There's no CI/CD in this repo (`.github/workflows` is empty) to automate it, and publishing a public package is not something I should trigger unilaterally. **Please publish from `main` at this exact commit** once merged — that's what makes the compiled npm artifact actually match what's in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
