### PR TITLE
fix(schemas): specify attachment content/url exclusivity and replyAll interaction

### DIFF
--- a/node/src/schemas.ts
+++ b/node/src/schemas.ts
@@ -80,8 +80,11 @@ const AttachmentSchema = z.object({
     contentType: z.string().optional().describe('MIME type of the attachment'),
     contentDisposition: z.enum(['inline', 'attachment']).optional().describe('Content disposition'),
     contentId: z.string().optional().describe('Content ID for inline attachments'),
-    content: z.string().optional().describe('Base64 encoded content'),
-    url: z.url().optional().describe('URL'),
+    content: z.string().optional().describe('Base64 encoded content. Exactly one of content or url must be provided'),
+    url: z
+        .url()
+        .optional()
+        .describe('Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided'),
 })
 
 const BaseMessageParams = z.object({
@@ -89,7 +92,10 @@ const BaseMessageParams = z.object({
     text: z.string().optional().describe('Plain text body'),
     html: z.string().optional().describe('HTML body'),
     labels: z.array(z.string()).optional().describe('Labels'),
-    attachments: z.array(AttachmentSchema).optional().describe('Attachments'),
+    attachments: z
+        .array(AttachmentSchema)
+        .optional()
+        .describe('Attachments. Each item must specify exactly one of content (base64) or url'),
 })
 
 export const SendMessageParams = BaseMessageParams.extend({
@@ -102,10 +108,16 @@ export const SendMessageParams = BaseMessageParams.extend({
 
 export const ReplyToMessageParams = BaseMessageParams.extend({
     messageId: MessageIdSchema,
-    replyAll: z.boolean().optional().describe('Reply to all recipients'),
-    to: z.array(z.string()).optional().describe('Override reply recipients'),
-    cc: z.array(z.string()).optional().describe('Override CC recipients'),
-    bcc: z.array(z.string()).optional().describe('Override BCC recipients'),
+    replyAll: z
+        .boolean()
+        .optional()
+        .describe('Reply to all original recipients. Mutually exclusive with to, cc, and bcc — the API rejects the request if both are set'),
+    to: z
+        .array(z.string())
+        .optional()
+        .describe('Override reply recipients, replacing the default (the original sender). Omit to reply to the sender only. Cannot be combined with replyAll'),
+    cc: z.array(z.string()).optional().describe('Override CC recipients. Cannot be combined with replyAll'),
+    bcc: z.array(z.string()).optional().describe('Override BCC recipients. Cannot be combined with replyAll'),
     replyTo: z.array(z.string()).optional().describe('Reply-to addresses'),
 })
 

--- a/python/src/agentmail_toolkit/schemas.py
+++ b/python/src/agentmail_toolkit/schemas.py
@@ -50,8 +50,13 @@ class GetAttachmentParams(BaseModel):
 class Attachment(BaseModel):
     filename: Optional[str] = Field(default=None, description="Filename")
     content_id: Optional[str] = Field(default=None, description="Content ID for inline attachments")
-    content: Optional[str] = Field(default=None, description="Base64 encoded content")
-    url: Optional[str] = Field(default=None, description="URL")
+    content: Optional[str] = Field(
+        default=None, description="Base64 encoded content. Exactly one of content or url must be provided"
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided",
+    )
 
 
 class BaseMessageParams(BaseModel):
@@ -59,7 +64,9 @@ class BaseMessageParams(BaseModel):
     text: Optional[str] = Field(default=None, description="Plain text body")
     html: Optional[str] = Field(default=None, description="HTML body")
     labels: Optional[List[str]] = Field(default=None, description="Labels")
-    attachments: Optional[List[Attachment]] = Field(default=None, description="Attachments")
+    attachments: Optional[List[Attachment]] = Field(
+        default=None, description="Attachments. Each item must specify exactly one of content (base64) or url"
+    )
 
 
 class SendMessageParams(BaseMessageParams):
@@ -71,7 +78,9 @@ class SendMessageParams(BaseMessageParams):
 
 class ReplyToMessageParams(BaseMessageParams):
     message_id: MessageIdField
-    reply_all: Optional[bool] = Field(default=None, description="Reply to all recipients")
+    reply_all: Optional[bool] = Field(
+        default=None, description="Reply to all original recipients. Omit or set false to reply to the sender only"
+    )
 
 
 class ForwardMessageParams(SendMessageParams):


### PR DESCRIPTION
## Why

OpenAI's MCP app review rejected the server with "Unclear Arguments" warnings on `send_message`, `reply_to_message`, and `forward_message`:

- attachment items allow both `content` and `url` with no stated relationship — "likely to miscall attachment payload"
- `replyAll` vs `to`/`cc`/`bcc` override interaction unspecified

## What

Description-only changes in both toolkit schemas (node + python) documenting what the API already enforces (`SendAttachmentSchema` and `ReplyMessageSchema` refines in agentmail-api):

- `content` / `url`: exactly one must be provided (stated on both fields and the shared `attachments` array, so send/reply/forward/drafts are all covered)
- `replyAll`: mutually exclusive with `to`/`cc`/`bcc` — the API rejects the combination
- reply `to`: documents the default (original sender) and the `replyAll` conflict

No behavior change; the API remains the enforcing layer.

## Verification

- node: 261 tests pass; python: 33 tests pass
- Ran the toolkit's actual zod→JSON Schema conversion (same `.shape` path `mcp.ts` uses) — all new descriptions survive into the advertised tool schema, including nested attachment items

## Release chain

Publish 0.5.1 → bump pin in agentmail-mcp server → redeploy → request OpenAI rescan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)