### PR TITLE
feat(node): AgentMailToolkit.invoke for per-call client injection (mcp)

### DIFF
--- a/node/src/mcp.ts
+++ b/node/src/mcp.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod'
 import { type ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { type ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
+import { type ToolAnnotations, type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { type AgentMailClient } from 'agentmail'
 
 import { ListToolkit } from './toolkit.js'
-import { type Tool } from './tools.js'
+import { type Tool, tools } from './tools.js'
 import { safeFunc, normalize, truncateForLog } from './util.js'
 
 interface McpTool {
@@ -16,6 +17,72 @@ interface McpTool {
     annotations?: ToolAnnotations
 }
 
+// Name -> Tool, built once at module load. Lets `invoke` dispatch by name without
+// reconstructing the whole tool set per call.
+const toolsByName: ReadonlyMap<string, Tool> = new Map(tools.map((tool) => [tool.name, tool]))
+
+// Execute one tool's func with an explicit client and shape the outcome as an MCP
+// CallToolResult. Shared by the per-instance `callback` (client bound at
+// construction) and `invoke` (client supplied per call) so both paths behave
+// identically - the client is the only thing that differs between them.
+async function runTool(
+    tool: Tool,
+    client: AgentMailClient,
+    args: Record<string, unknown>
+): Promise<CallToolResult> {
+    const { isError, result, statusCode, body } = await safeFunc(tool.func, client, args)
+    if (isError) {
+        // Errors are returned as isError tool results (HTTP 200), so they never
+        // reach the host's error logs on their own. Log here, at the real catch
+        // site, so failures are actually observable. Error results are never
+        // validated against outputSchema - the MCP SDK itself skips output
+        // validation when isError is true, so we don't either.
+        console.error('[agentmail-toolkit] tool error', {
+            tool: tool.name,
+            statusCode,
+            body: truncateForLog(body),
+        })
+        return {
+            content: [{ type: 'text' as const, text: String(result) }],
+            isError: true,
+        }
+    }
+
+    // JSON-safe the result (Date -> ISO string) and validate it against the
+    // tool's own output schema before returning structuredContent. Schema
+    // drift (a func/schema mismatch) must fail visibly rather than silently
+    // handing the client malformed structured content.
+    //
+    // Parse in strip mode (z.object of the same shape), not with the loose
+    // schema directly: the MCP SDK reconstructs a plain z.object from the raw
+    // shape we register and advertises it to clients with a strict
+    // (additionalProperties: false) root. Stripping unknown top-level keys
+    // here keeps structuredContent conformant with that ADVERTISED schema, so
+    // a future SDK field is dropped instead of failing validation in strict
+    // clients. Nested objects keep their looseness (they serialize from the
+    // real looseObject instances in the shape).
+    const parsed = z.object(tool.outputSchema.shape).safeParse(normalize(result))
+    if (!parsed.success) {
+        console.error('[agentmail-toolkit] output schema mismatch', {
+            tool: tool.name,
+            issues: parsed.error.issues,
+        })
+        return {
+            content: [{ type: 'text' as const, text: `Internal error: ${tool.name} result did not match its declared output schema` }],
+            isError: true,
+        }
+    }
+
+    // Backwards compatibility: also serialize the same structuredContent as text.
+    const structuredContent = parsed.data as Record<string, unknown>
+    const text = JSON.stringify(structuredContent)
+    return {
+        structuredContent,
+        content: [{ type: 'text' as const, text }],
+        isError: false,
+    }
+}
+
 export class AgentMailToolkit extends ListToolkit<McpTool> {
     protected buildTool(tool: Tool): McpTool {
         return {
@@ -24,60 +91,39 @@ export class AgentMailToolkit extends ListToolkit<McpTool> {
             description: tool.description,
             inputSchema: tool.paramsSchema.shape,
             outputSchema: tool.outputSchema.shape,
-            callback: async (args) => {
-                const { isError, result, statusCode, body } = await safeFunc(tool.func, this.client, args)
-                if (isError) {
-                    // Errors are returned as isError tool results (HTTP 200), so they never
-                    // reach the host's error logs on their own. Log here, at the real catch
-                    // site, so failures are actually observable. Error results are never
-                    // validated against outputSchema - the MCP SDK itself skips output
-                    // validation when isError is true, so we don't either.
-                    console.error('[agentmail-toolkit] tool error', {
-                        tool: tool.name,
-                        statusCode,
-                        body: truncateForLog(body),
-                    })
-                    return {
-                        content: [{ type: 'text' as const, text: String(result) }],
-                        isError: true,
-                    }
-                }
-
-                // JSON-safe the result (Date -> ISO string) and validate it against the
-                // tool's own output schema before returning structuredContent. Schema
-                // drift (a func/schema mismatch) must fail visibly rather than silently
-                // handing the client malformed structured content.
-                //
-                // Parse in strip mode (z.object of the same shape), not with the loose
-                // schema directly: the MCP SDK reconstructs a plain z.object from the raw
-                // shape we register and advertises it to clients with a strict
-                // (additionalProperties: false) root. Stripping unknown top-level keys
-                // here keeps structuredContent conformant with that ADVERTISED schema, so
-                // a future SDK field is dropped instead of failing validation in strict
-                // clients. Nested objects keep their looseness (they serialize from the
-                // real looseObject instances in the shape).
-                const parsed = z.object(tool.outputSchema.shape).safeParse(normalize(result))
-                if (!parsed.success) {
-                    console.error('[agentmail-toolkit] output schema mismatch', {
-                        tool: tool.name,
-                        issues: parsed.error.issues,
-                    })
-                    return {
-                        content: [{ type: 'text' as const, text: `Internal error: ${tool.name} result did not match its declared output schema` }],
-                        isError: true,
-                    }
-                }
-
-                // Backwards compatibility: also serialize the same structuredContent as text.
-                const structuredContent = parsed.data as Record<string, unknown>
-                const text = JSON.stringify(structuredContent)
-                return {
-                    structuredContent,
-                    content: [{ type: 'text' as const, text }],
-                    isError: false,
-                }
-            },
+            callback: async (args) => runTool(tool, this.client, args as Record<string, unknown>),
             annotations: tool.annotations,
         }
+    }
+
+    /**
+     * Invoke a tool by name with a per-call client, bypassing the client bound
+     * at construction, and return the same MCP CallToolResult a tools/call
+     * would.
+     *
+     * This lets a host that serves many users (e.g. a hosted MCP server) build
+     * the toolkit ONCE and hand each request its own client, instead of
+     * constructing a fresh toolkit per request and again per tool call - which,
+     * under long-lived/streaming connections, retains a per-call object graph
+     * and drives heap growth.
+     *
+     * An unknown tool name returns an isError result rather than throwing, so a
+     * bad name can never crash the caller. `args` is assumed already validated
+     * against the tool's paramsSchema (the MCP SDK validates tools/call
+     * arguments before dispatch).
+     */
+    async invoke(
+        name: string,
+        client: AgentMailClient,
+        args: Record<string, unknown>
+    ): Promise<CallToolResult> {
+        const tool = toolsByName.get(name)
+        if (!tool) {
+            return {
+                content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }],
+                isError: true,
+            }
+        }
+        return runTool(tool, client, args)
     }
 }

--- a/node/tests/mcp.test.ts
+++ b/node/tests/mcp.test.ts
@@ -6,7 +6,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 
 import { AgentMailToolkit } from '../src/mcp.js'
 import { tools } from '../src/tools.js'
-import { mockClient, argsByTool } from './fixtures.js'
+import { mockClient, argsByTool, inbox } from './fixtures.js'
 
 // Real MCP SDK client <-> server over an in-memory transport: the same protocol
 // surface (tools/list, tools/call, client-side structuredContent validation
@@ -143,5 +143,58 @@ describe('tools/call', () => {
         expect(result.isError).toBe(true)
         const content = result.content as Array<{ text: string }>
         expect(content[0].text).toMatch(/output schema/)
+    })
+})
+
+// A client whose list_inboxes returns a single inbox tagged with `marker`, so a test
+// can tell which client actually served a call.
+function inboxListClient(marker: string): AgentMailClient {
+    return {
+        inboxes: { list: async () => ({ count: 1, inboxes: [{ ...inbox(), inboxId: marker }] }) },
+    } as unknown as AgentMailClient
+}
+
+describe('invoke (stateless per-call client)', () => {
+    it('runs the tool with the client passed to invoke, not the one bound at construction', async () => {
+        // A host that serves many users builds the toolkit once (bound client is a
+        // placeholder) and hands a real per-request client to each call.
+        const toolkit = new AgentMailToolkit(inboxListClient('BOUND'))
+        const result = await toolkit.invoke('list_inboxes', inboxListClient('PER_CALL'), {})
+
+        expect(result.isError ?? false).toBe(false)
+        const structured = result.structuredContent as { inboxes: Array<{ inboxId: string }> }
+        expect(structured.inboxes[0].inboxId).toBe('PER_CALL')
+        // Same text/structured parity a tools/call returns.
+        const content = result.content as Array<{ type: string; text: string }>
+        expect(JSON.parse(content[0].text)).toEqual(structured)
+    })
+
+    it('returns an isError result for an unknown tool name instead of throwing', async () => {
+        const toolkit = new AgentMailToolkit(mockClient())
+        const result = await toolkit.invoke('does_not_exist', mockClient(), {})
+        expect(result.isError).toBe(true)
+    })
+
+    it('surfaces AgentMail errors as an isError result with a concise, bounded message', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const failing = {
+            inboxes: {
+                list: async () => {
+                    throw new AgentMailError({
+                        message: 'Status code: 403\nBody: ...',
+                        statusCode: 403,
+                        body: { message: 'Forbidden' },
+                    })
+                },
+            },
+        } as unknown as AgentMailClient
+        const toolkit = new AgentMailToolkit(mockClient())
+        const result = await toolkit.invoke('list_inboxes', failing, {})
+
+        expect(result.isError).toBe(true)
+        const content = result.content as Array<{ text: string }>
+        expect(content[0].text).toContain('Forbidden')
+        expect(content[0].text).toContain('403')
+        expect(result.structuredContent).toBeUndefined()
     })
 })


### PR DESCRIPTION
## What

Adds `AgentMailToolkit.invoke(name, client, args)` to the MCP adapter — run a tool by name with a **per-call client**, returning the same `CallToolResult` a `tools/call` would.

## Why

The MCP `AgentMailToolkit` binds its client at construction. A host that serves many users (the hosted MCP server at `mcp.agentmail.to`) therefore builds a fresh toolkit **per request** (to enumerate tool definitions) **and again per tool call** (to bind the request's client). Under long-lived / streaming (SSE) connections each of those per-call object graphs is retained until the connection closes — under a reconnect burst that contributes to heap exhaustion (we saw `JS heap out of memory` in production).

With `invoke`, a host builds the toolkit **once** and hands each call its own client — no per-request/per-call toolkit allocation:

```ts
const toolkit = new AgentMailToolkit()          // once
// tool definitions for registration: toolkit.getTools()
// per call: await toolkit.invoke(name, perRequestClient, args)
```

## How

- Extract the existing `buildTool` callback body into a shared module-level `runTool(tool, client, args)`.
- `buildTool`'s callback and the new `invoke` both delegate to `runTool` — identical behavior; the only difference is where the client comes from.
- Unknown tool name → `isError` result (never throws).

## Compatibility

Purely additive. `getTools()` / `callback` shape and behavior are unchanged.

## Tests

`node/tests/mcp.test.ts` adds coverage for per-call client selection (bound vs passed), unknown-tool handling, and error surfacing. Full node suite: **264 passing**. `tsc --noEmit`, `tsup` build, and `eslint` all clean.

## Versioning

Left `package.json` version untouched (the repo tracks releases via separate release branches). Suggest publishing this as a minor bump — new feature, backward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
