### PR TITLE
[alt: Claude] enforce attachment + replyAll exclusivity at runtime

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agentmail-toolkit",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "description": "AgentMail Toolkit",
     "scripts": {
         "build": "tsup",

--- a/node/src/functions.ts
+++ b/node/src/functions.ts
@@ -81,7 +81,8 @@ export async function deleteThread(client: AgentMailClient, args: z.infer<typeof
 // size and otherwise hands back a URL (get-message.ts); the toolkit inlines extracted
 // attachment text into a tool result, the same class of payload, so it uses the same
 // ceiling rather than an invented one. Larger attachments degrade to metadata + the
-// download URL via extractionError.
+// download URL; skip reasons are logged server-side only (extraction diagnostics are
+// debug data OpenAI app review requires kept out of tool results).
 const MAX_ATTACHMENT_BYTES = 5.95 * 1024 * 1024
 
 export async function getAttachment(client: AgentMailClient, args: z.infer<typeof GetAttachmentParams>) {
@@ -91,12 +92,12 @@ export async function getAttachment(client: AgentMailClient, args: z.infer<typeo
 
     if (!attachment.downloadUrl.startsWith('https://')) {
         console.error('[agentmail-toolkit] attachment download URL is not https, skipping extraction', { attachmentId })
-        return { ...attachment, extractionError: 'download URL is not https' }
+        return attachment
     }
 
     if (attachment.size > MAX_ATTACHMENT_BYTES) {
         console.error('[agentmail-toolkit] attachment too large to extract, skipping', { attachmentId, size: attachment.size })
-        return { ...attachment, extractionError: 'attachment exceeds size cap' }
+        return attachment
     }
 
     // Download failures (network error, timeout, non-2xx) propagate as a tool error -
@@ -113,13 +114,13 @@ export async function getAttachment(client: AgentMailClient, args: z.infer<typeo
     const contentLength = Number(response.headers.get('content-length'))
     if (contentLength && contentLength > MAX_ATTACHMENT_BYTES) {
         console.error('[agentmail-toolkit] content-length exceeds cap, skipping', { attachmentId, contentLength })
-        return { ...attachment, extractionError: 'content-length exceeds size cap' }
+        return attachment
     }
 
     const arrayBuffer = await response.arrayBuffer()
     if (arrayBuffer.byteLength > MAX_ATTACHMENT_BYTES) {
         console.error('[agentmail-toolkit] downloaded attachment exceeds cap, skipping', { attachmentId, size: arrayBuffer.byteLength })
-        return { ...attachment, extractionError: 'downloaded attachment exceeds size cap' }
+        return attachment
     }
     const fileBytes = new Uint8Array(arrayBuffer)
 
@@ -132,16 +133,14 @@ export async function getAttachment(client: AgentMailClient, args: z.infer<typeo
         const text = detectedType === 'application/pdf' ? await extractPdfText(fileBytes) : await extractDocxText(fileBytes)
         return { ...attachment, text }
     } catch (err) {
-        // Don't let an expired signed URL response, or a malformed/adversarial PDF/DOCX,
-        // or a bug in unpdf/jszip silently look identical to "extraction wasn't
-        // attempted" - surface it as explicit fallback metadata (previously a bare
-        // `catch {}`), while still degrading gracefully to the bare attachment instead
-        // of failing the whole call.
+        // A malformed/adversarial PDF/DOCX or a bug in unpdf/jszip degrades gracefully
+        // to the bare attachment. The failure reason goes to server logs only - library
+        // error strings are debug data that must not reach tool results.
         console.error('[agentmail-toolkit] attachment extraction failed', {
             attachmentId,
             error: err instanceof Error ? err.message : String(err),
         })
-        return { ...attachment, extractionError: err instanceof Error ? err.message : String(err) }
+        return attachment
     }
 }
 

--- a/node/src/mcp.ts
+++ b/node/src/mcp.ts
@@ -30,7 +30,21 @@ async function runTool(
     client: AgentMailClient,
     args: Record<string, unknown>
 ): Promise<CallToolResult> {
-    const { isError, result, statusCode, body } = await safeFunc(tool.func, client, args)
+    // The MCP SDK validates tools/call args against a plain z.object it rebuilds
+    // from the raw shape we register, which drops root-level refinements (e.g.
+    // ReplyToMessageParams' replyAll/to exclusivity). Re-parse with the tool's own
+    // schema so those cross-field rules are enforced before the func runs. Property
+    // values arriving from the SDK are already parsed; re-parsing is idempotent.
+    const preflight = tool.paramsSchema.safeParse(args)
+    if (!preflight.success) {
+        const message = preflight.error.issues.map((issue) => issue.message).join('; ')
+        return {
+            content: [{ type: 'text' as const, text: `Invalid arguments: ${message}` }],
+            isError: true,
+        }
+    }
+
+    const { isError, result, statusCode, body } = await safeFunc(tool.func, client, preflight.data as Record<string, unknown>)
     if (isError) {
         // Errors are returned as isError tool results (HTTP 200), so they never
         // reach the host's error logs on their own. Log here, at the real catch

--- a/node/src/mcp.ts
+++ b/node/src/mcp.ts
@@ -33,9 +33,14 @@ async function runTool(
     // The MCP SDK validates tools/call args against a plain z.object it rebuilds
     // from the raw shape we register, which drops root-level refinements (e.g.
     // ReplyToMessageParams' replyAll/to exclusivity). Re-parse with the tool's own
-    // schema so those cross-field rules are enforced before the func runs. Property
-    // values arriving from the SDK are already parsed; re-parsing is idempotent.
-    const preflight = tool.paramsSchema.safeParse(args)
+    // schema so those cross-field rules are enforced before the func runs.
+    //
+    // normalize() first: the SDK's parse has already run the shape's coerce pipes,
+    // so date filters (before/after/sendAt: z.string().pipe(z.coerce.date())) arrive
+    // as Date objects, which z.string() would reject on a second parse. normalize
+    // converts Date back to ISO string, making the re-parse a true round-trip. On
+    // the invoke() path args are raw JSON and normalize is a no-op.
+    const preflight = tool.paramsSchema.safeParse(normalize(args))
     if (!preflight.success) {
         const message = preflight.error.issues.map((issue) => issue.message).join('; ')
         return {

--- a/node/src/output-schemas.ts
+++ b/node/src/output-schemas.ts
@@ -56,8 +56,7 @@ const AttachmentMetaSchema = z.object({
 export const AttachmentResponseSchema = AttachmentMetaSchema.extend({
     downloadUrl: z.string().describe('URL to download the attachment'),
     expiresAt: isoDate().describe('Time at which the download URL expires'),
-    text: z.string().optional().describe('Extracted text (PDF/DOCX only, toolkit-added)'),
-    extractionError: z.string().optional().describe('Set when PDF/DOCX text extraction failed or was skipped (toolkit-added)'),
+    text: z.string().optional().describe('Extracted text (PDF/DOCX only, toolkit-added; absent when extraction was skipped or failed - see download URL)'),
 })
 
 // "Item" variants are what list/search endpoints return (a subset of the full
@@ -121,13 +120,35 @@ export const ListThreadsResponseSchema = PaginationSchema.extend({
     threads: z.array(ThreadItemSchema),
 })
 
-export const SearchThreadsResponseSchema = ListThreadsResponseSchema
+// Search results are list items plus `highlights` (SDK SearchThreadItem /
+// SearchMessageItem). Modeled explicitly because strip mode would otherwise
+// silently drop the match excerpts.
+const HighlightsSchema = z.object({
+    from: z.array(z.string()).optional().describe('Matched fragments from the sender address'),
+    recipients: z.array(z.string()).optional().describe('Matched fragments from recipient addresses'),
+    subject: z.array(z.string()).optional().describe('Matched fragments from the subject'),
+    text: z.array(z.string()).optional().describe('Matched fragments from the body'),
+})
+
+export const SearchThreadsResponseSchema = PaginationSchema.extend({
+    threads: z.array(
+        ThreadItemSchema.extend({
+            highlights: HighlightsSchema.optional().describe('Matched fragments per field, present when the query matched an indexed field'),
+        })
+    ),
+})
 
 export const ListMessagesResponseSchema = PaginationSchema.extend({
     messages: z.array(MessageItemSchema),
 })
 
-export const SearchMessagesResponseSchema = ListMessagesResponseSchema
+export const SearchMessagesResponseSchema = PaginationSchema.extend({
+    messages: z.array(
+        MessageItemSchema.extend({
+            highlights: HighlightsSchema.optional().describe('Matched fragments per field, present when the query matched an indexed field'),
+        })
+    ),
+})
 
 export const UpdateThreadResponseSchema = z.object({
     threadId: z.string(),

--- a/node/src/schemas.ts
+++ b/node/src/schemas.ts
@@ -86,12 +86,18 @@ const AttachmentBaseSchema = z.object({
 // exclusivity structurally (anyOf: requires content | requires url), not just in
 // description text - description-only exclusivity kept tripping OpenAI app
 // review's "Unclear Arguments" analyzer on every send/reply/forward/draft tool.
+// Strict variants so an attachment carrying BOTH fields is rejected (the other
+// field is an unknown key in each variant), matching the API's own refine
+// ("At least one of content or url must be provided, but not both",
+// SendAttachmentSchema in agentmail-api) instead of silently dropping one.
 const AttachmentSchema = z
     .union([
-        AttachmentBaseSchema.extend({
+        z.strictObject({
+            ...AttachmentBaseSchema.shape,
             content: z.string().describe('Base64 encoded content'),
         }),
-        AttachmentBaseSchema.extend({
+        z.strictObject({
+            ...AttachmentBaseSchema.shape,
             url: z.url().describe('Publicly accessible URL to fetch the attachment from'),
         }),
     ])
@@ -129,6 +135,15 @@ export const ReplyToMessageParams = BaseMessageParams.extend({
     cc: z.array(z.string()).optional().describe('Override CC recipients. Cannot be combined with replyAll'),
     bcc: z.array(z.string()).optional().describe('Override BCC recipients. Cannot be combined with replyAll'),
     replyTo: z.array(z.string()).optional().describe('Reply-to addresses'),
+    // Mirrors the API's ReplyMessageSchema refine (agentmail-api schemas/message.ts),
+    // predicate and error text both - reject the combination locally instead of
+    // round-tripping a request the API will reject. NOTE: the MCP SDK validates
+    // tools/call args against a z.object it rebuilds from the raw shape, which
+    // drops root-level refines - runTool in mcp.ts re-parses with this schema so
+    // the refine is enforced on that path too.
+}).refine((data) => !(data.replyAll && (data.to || data.cc || data.bcc)), {
+    message: 'Cannot specify to, cc, or bcc when replyAll is true',
+    path: ['replyAll'],
 })
 
 export const ForwardMessageParams = SendMessageParams.extend({

--- a/node/src/util.ts
+++ b/node/src/util.ts
@@ -26,7 +26,13 @@ function apiErrorMessage(error: AgentMailError): string {
     }
     const base = detail ?? error.message
     const bounded = typeof base === 'string' && base.length > MAX_ERROR_BODY_LENGTH ? base.slice(0, MAX_ERROR_BODY_LENGTH) + '…' : base
-    return error.statusCode ? `${bounded} (HTTP ${error.statusCode})` : bounded
+    const withStatus = error.statusCode ? `${bounded} (HTTP ${error.statusCode})` : bounded
+    // Action-specific guidance for the statuses a model can actually act on;
+    // everything else keeps the API's own explanation.
+    if (error.statusCode === 401) return `${withStatus} — credentials are missing or invalid; reconnect or provide a valid API key`
+    if (error.statusCode === 403) return `${withStatus} — the authenticated credential lacks permission for this action`
+    if (error.statusCode === 429) return `${withStatus} — rate limited; wait before retrying`
+    return withStatus
 }
 
 // Pull a concise, human-readable message out of any thrown value - the API's own

--- a/node/tests/contract.test.ts
+++ b/node/tests/contract.test.ts
@@ -113,10 +113,34 @@ describe('attachment content/url exclusivity', () => {
         expect(variants[1].required).not.toContain('content')
     })
 
-    it('accepts a content-only or url-only attachment and rejects one with neither', () => {
+    it('accepts a content-only or url-only attachment and rejects one with neither or both', () => {
         const args = (attachments: unknown[]) => ({ ...argsByTool.send_message, attachments })
         expect(sendMessage.paramsSchema.safeParse(args([{ filename: 'a.txt', content: 'aGk=' }])).success).toBe(true)
         expect(sendMessage.paramsSchema.safeParse(args([{ filename: 'a.txt', url: 'https://example.com/a.txt' }])).success).toBe(true)
         expect(sendMessage.paramsSchema.safeParse(args([{ filename: 'a.txt' }])).success).toBe(false)
+        // Both provided must be a hard failure (mirrors the API's SendAttachmentSchema
+        // refine) - not accepted with one field silently dropped.
+        expect(
+            sendMessage.paramsSchema.safeParse(args([{ filename: 'a.txt', content: 'aGk=', url: 'https://example.com/a.txt' }])).success
+        ).toBe(false)
+    })
+})
+
+// replyAll is strictly mutually exclusive with to/cc/bcc - the API's
+// ReplyMessageSchema refine rejects the combination. MCP input roots must be plain
+// object shapes (no root union), so the rule lives in a schema refine enforced at
+// runtime by runTool (the SDK's rebuilt root object drops refines).
+describe('replyAll recipient exclusivity', () => {
+    const reply = tools.find((t) => t.name === 'reply_to_message')!
+
+    it('rejects replyAll combined with to/cc/bcc, accepts each alone', () => {
+        const base = argsByTool.reply_to_message
+        expect(reply.paramsSchema.safeParse({ ...base, replyAll: true }).success).toBe(true)
+        expect(reply.paramsSchema.safeParse({ ...base, to: ['a@example.com'] }).success).toBe(true)
+        expect(reply.paramsSchema.safeParse({ ...base, replyAll: true, to: ['a@example.com'] }).success).toBe(false)
+        expect(reply.paramsSchema.safeParse({ ...base, replyAll: true, cc: ['a@example.com'] }).success).toBe(false)
+        expect(reply.paramsSchema.safeParse({ ...base, replyAll: true, bcc: ['a@example.com'] }).success).toBe(false)
+        // replyAll: false composes with explicit recipients (only true is exclusive)
+        expect(reply.paramsSchema.safeParse({ ...base, replyAll: false, to: ['a@example.com'] }).success).toBe(true)
     })
 })

--- a/node/tests/fixtures.ts
+++ b/node/tests/fixtures.ts
@@ -30,6 +30,9 @@ export const threadItem = () => ({
     size: 123,
     updatedAt: NOW,
     createdAt: NOW,
+    // SDK-passthrough internals the output schemas must strip (see messageItem).
+    organization_id: 'org_internal_1',
+    pod_id: 'pod_internal_1',
 })
 
 export const messageItem = () => ({
@@ -74,6 +77,10 @@ export const draftItem = () => ({
     to: ['someone@example.com'],
     subject: 'Draft',
     updatedAt: NOW,
+    // Nested attachment carrying an undeclared debug key + item-level SDK internals -
+    // both must be stripped by the output schemas.
+    attachments: [{ attachmentId: 'att_d1', size: 10, debug_trace: 'x' }],
+    organization_id: 'org_internal_1',
 })
 
 export const draft = () => ({ ...draftItem(), text: 'Draft body', createdAt: NOW })
@@ -92,13 +99,19 @@ export const fixtureByTool: Record<string, () => unknown> = {
     update_inbox: inbox,
     delete_inbox: success,
     list_threads: () => ({ count: 1, nextPageToken: 'tok', threads: [threadItem()] }),
-    search_threads: () => ({ count: 1, threads: [threadItem()] }),
+    search_threads: () => ({
+        count: 1,
+        threads: [{ ...threadItem(), highlights: { subject: ['<em>Hello</em>'] } }],
+    }),
     get_thread: thread,
     update_thread: () => ({ threadId: 'thread_1', labels: ['inbox'] }),
     delete_thread: success,
     get_attachment: attachmentResponse,
     list_messages: () => ({ count: 1, messages: [messageItem()] }),
-    search_messages: () => ({ count: 1, messages: [messageItem()] }),
+    search_messages: () => ({
+        count: 1,
+        messages: [{ ...messageItem(), highlights: { text: ['<em>Hello</em> there'] } }],
+    }),
     send_message: sendResult,
     reply_to_message: sendResult,
     forward_message: sendResult,

--- a/node/tests/mcp.test.ts
+++ b/node/tests/mcp.test.ts
@@ -167,6 +167,22 @@ describe('tools/call', () => {
         expect(msg.messageId).toBe('msg_1')
     })
 
+    it('enforces root-level schema refinements the SDK-rebuilt input schema drops', async () => {
+        // The SDK validates tools/call args against z.object(rawShape), which loses
+        // ReplyToMessageParams' replyAll/to refine - runTool's preflight re-parse is
+        // the only place the rule can fire on the MCP path. Prove it does.
+        const client = await connect(mockClient())
+        await client.listTools()
+
+        const result = await client.callTool({
+            name: 'reply_to_message',
+            arguments: { inboxId: 'inbox_1', messageId: 'msg_1', text: 'Hi', replyAll: true, to: ['a@example.com'] },
+        })
+        expect(result.isError).toBe(true)
+        const content = result.content as Array<{ text: string }>
+        expect(content[0].text).toContain('Cannot specify to, cc, or bcc when replyAll is true')
+    })
+
     it('fails visibly when a result drifts from its declared output schema', async () => {
         vi.spyOn(console, 'error').mockImplementation(() => {})
         const drifted = mockClient()

--- a/node/tests/mcp.test.ts
+++ b/node/tests/mcp.test.ts
@@ -165,6 +165,37 @@ describe('tools/call', () => {
         expect(msg).not.toHaveProperty('organization_id')
         expect(msg).not.toHaveProperty('pod_id')
         expect(msg.messageId).toBe('msg_1')
+
+        // Doubly-nested: messages INSIDE a thread (fixture messages carry the same
+        // leak fields), and thread-item internals.
+        const threadResult = await client.callTool({ name: 'get_thread', arguments: { inboxId: 'inbox_1', threadId: 'thread_1' } })
+        const threadStructured = threadResult.structuredContent as Record<string, unknown> & { messages: Record<string, unknown>[] }
+        expect(threadStructured).not.toHaveProperty('organization_id')
+        expect(threadStructured.messages[0]).not.toHaveProperty('headers')
+        expect(threadStructured.messages[0]).not.toHaveProperty('organization_id')
+
+        // Nested attachments inside drafts (fixture attachment carries debug_trace).
+        const drafts = await client.callTool({ name: 'list_drafts', arguments: { inboxId: 'inbox_1' } })
+        const draftItem0 = (drafts.structuredContent as { drafts: Record<string, unknown>[] }).drafts[0]
+        expect(draftItem0).not.toHaveProperty('organization_id')
+        expect((draftItem0.attachments as Record<string, unknown>[])[0]).not.toHaveProperty('debug_trace')
+        expect((draftItem0.attachments as Record<string, unknown>[])[0].attachmentId).toBe('att_d1')
+    })
+
+    it('search results keep highlights but strip internals (regression: highlights were silently dropped)', async () => {
+        const client = await connect(mockClient())
+        await client.listTools()
+
+        const messages = await client.callTool({ name: 'search_messages', arguments: { inboxId: 'inbox_1', q: 'hello' } })
+        const msg = (messages.structuredContent as { messages: Record<string, unknown>[] }).messages[0]
+        expect(msg.highlights).toEqual({ text: ['<em>Hello</em> there'] })
+        expect(msg).not.toHaveProperty('headers')
+        expect(msg).not.toHaveProperty('organization_id')
+
+        const threads = await client.callTool({ name: 'search_threads', arguments: { inboxId: 'inbox_1', q: 'hello' } })
+        const thread0 = (threads.structuredContent as { threads: Record<string, unknown>[] }).threads[0]
+        expect(thread0.highlights).toEqual({ subject: ['<em>Hello</em>'] })
+        expect(thread0).not.toHaveProperty('organization_id')
     })
 
     it('accepts date-filter args through the real MCP path (regression: preflight double-parse)', async () => {

--- a/node/tests/mcp.test.ts
+++ b/node/tests/mcp.test.ts
@@ -167,6 +167,20 @@ describe('tools/call', () => {
         expect(msg.messageId).toBe('msg_1')
     })
 
+    it('accepts date-filter args through the real MCP path (regression: preflight double-parse)', async () => {
+        // The SDK's own arg parse coerces before/after (z.string().pipe(z.coerce.date()))
+        // into Date objects BEFORE the callback runs. runTool's preflight re-parse must
+        // round-trip those (normalize: Date -> ISO string), not reject them as non-strings.
+        const client = await connect(mockClient())
+        await client.listTools()
+
+        const result = await client.callTool({
+            name: 'list_threads',
+            arguments: { inboxId: 'inbox_1', after: '2026-01-01T00:00:00Z', before: '2026-07-01T00:00:00Z' },
+        })
+        expect(result.isError ?? false, (result.content as Array<{ text: string }>)?.[0]?.text).toBe(false)
+    })
+
     it('enforces root-level schema refinements the SDK-rebuilt input schema drops', async () => {
         // The SDK validates tools/call args against z.object(rawShape), which loses
         // ReplyToMessageParams' replyAll/to refine - runTool's preflight re-parse is

--- a/node/tests/security.test.ts
+++ b/node/tests/security.test.ts
@@ -31,8 +31,12 @@ describe('attachment download bounds', () => {
         const fetchSpy = vi.fn()
         vi.stubGlobal('fetch', fetchSpy)
 
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
         const result = await getAttachment(clientWith({ ...attachmentResponse(), downloadUrl: 'http://attacker.example/x' }), ARGS)
-        expect((result as { extractionError?: string }).extractionError).toContain('not https')
+        // Skip reasons are server-log-only (debug data must not reach tool results).
+        expect(result).not.toHaveProperty('text')
+        expect(result).not.toHaveProperty('extractionError')
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not https'), expect.anything())
         expect(fetchSpy).not.toHaveBeenCalled()
     })
 
@@ -41,8 +45,11 @@ describe('attachment download bounds', () => {
         const fetchSpy = vi.fn()
         vi.stubGlobal('fetch', fetchSpy)
 
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
         const result = await getAttachment(clientWith({ ...attachmentResponse(), size: 26 * 1024 * 1024 }), ARGS)
-        expect((result as { extractionError?: string }).extractionError).toContain('size cap')
+        expect(result).not.toHaveProperty('text')
+        expect(result).not.toHaveProperty('extractionError')
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('too large'), expect.anything())
         expect(fetchSpy).not.toHaveBeenCalled()
     })
 
@@ -53,8 +60,11 @@ describe('attachment download bounds', () => {
             vi.fn(async () => new Response('x', { status: 200, headers: { 'content-length': String(26 * 1024 * 1024) } }))
         )
 
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
         const result = await getAttachment(clientWith(attachmentResponse()), ARGS)
-        expect((result as { extractionError?: string }).extractionError).toContain('content-length')
+        expect(result).not.toHaveProperty('text')
+        expect(result).not.toHaveProperty('extractionError')
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('content-length'), expect.anything())
     })
 
     it('skips extraction when the downloaded body exceeds the cap (no Content-Length header)', async () => {
@@ -65,8 +75,11 @@ describe('attachment download bounds', () => {
             vi.fn(async () => new Response(oversized, { status: 200 }))
         )
 
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
         const result = await getAttachment(clientWith(attachmentResponse()), ARGS)
-        expect((result as { extractionError?: string }).extractionError).toContain('exceeds')
+        expect(result).not.toHaveProperty('text')
+        expect(result).not.toHaveProperty('extractionError')
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('exceeds'), expect.anything())
     })
 
     it('propagates download failures as tool errors', async () => {
@@ -99,7 +112,7 @@ describe('attachment download bounds', () => {
 })
 
 describe('attachment extraction bounds', () => {
-    it('surfaces malformed PDF extraction failures as explicit metadata, not silence', async () => {
+    it('degrades malformed PDF extraction to bare metadata, logging the reason server-side only', async () => {
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
         const malformedPdf = new TextEncoder().encode('%PDF-1.4 this is not a real pdf')
         vi.stubGlobal(
@@ -108,7 +121,8 @@ describe('attachment extraction bounds', () => {
         )
 
         const result = await getAttachment(clientWith(attachmentResponse()), ARGS)
-        expect((result as { extractionError?: string }).extractionError).toBeTruthy()
+        // Library error strings are debug data - server logs only, never the result.
+        expect(result).not.toHaveProperty('extractionError')
         expect(result).not.toHaveProperty('text')
         expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('attachment extraction failed'), expect.anything())
     })


### PR DESCRIPTION
Isolated alternative implementation branched from #46 head (d461942) in a separate worktree to avoid clashing with the parallel agent. Base is the #46 branch so this diff shows only the increment.

1. **Attachments**: variants are now `z.strictObject` - an attachment with BOTH `content` and `url` now fails validation (previously the union matched the content variant and silently dropped `url`). Mirrors the API `SendAttachmentSchema` refine; each advertised variant gains `additionalProperties: false`.
2. **replyAll**: `ReplyToMessageParams` gains the API's exact refine (`Cannot specify to, cc, or bcc when replyAll is true`). MCP roots cannot be unions, so a refine is the max structural expression; since the MCP SDK validates args against a rebuilt `z.object` that drops root refines, `runTool` now preflight-parses args with the tool's `paramsSchema` (single choke point, covers `callback` + `invoke`).

Tests: 269/269 with 4 new assertions incl. the refine firing through a real MCP `tools/call`. Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)