### PR TITLE
Give the model the API's remedy, and a tool to act on it

### DIFF
--- a/node/src/functions.ts
+++ b/node/src/functions.ts
@@ -23,6 +23,8 @@ import {
     UpdateDraftParams,
     SendDraftParams,
     DeleteDraftParams,
+    AgentSignUpParams,
+    AgentVerifyParams,
 } from './schemas.js'
 
 export async function listInboxes(client: AgentMailClient, args: z.infer<typeof ListItemsParams>) {
@@ -209,4 +211,12 @@ export async function deleteDraft(client: AgentMailClient, args: z.infer<typeof 
 
 export async function authMe(client: AgentMailClient) {
     return client.auth.me()
+}
+
+export async function agentSignUp(client: AgentMailClient, args: z.infer<typeof AgentSignUpParams>) {
+    return client.agent.signUp(args)
+}
+
+export async function agentVerify(client: AgentMailClient, args: z.infer<typeof AgentVerifyParams>) {
+    return client.agent.verify(args)
 }

--- a/node/src/functions.ts
+++ b/node/src/functions.ts
@@ -23,7 +23,6 @@ import {
     UpdateDraftParams,
     SendDraftParams,
     DeleteDraftParams,
-    AgentSignUpParams,
     AgentVerifyParams,
 } from './schemas.js'
 
@@ -211,10 +210,6 @@ export async function deleteDraft(client: AgentMailClient, args: z.infer<typeof 
 
 export async function authMe(client: AgentMailClient) {
     return client.auth.me()
-}
-
-export async function agentSignUp(client: AgentMailClient, args: z.infer<typeof AgentSignUpParams>) {
-    return client.agent.signUp(args)
 }
 
 export async function agentVerify(client: AgentMailClient, args: z.infer<typeof AgentVerifyParams>) {

--- a/node/src/output-schemas.ts
+++ b/node/src/output-schemas.ts
@@ -205,3 +205,13 @@ export const IdentitySchema = z.object({
     inboxId: z.string().optional(),
     apiKeyId: z.string().optional(),
 })
+
+export const AgentSignUpResponseSchema = z.object({
+    organizationId: z.string().describe('ID of the created organization'),
+    inboxId: z.string().describe('ID of the auto-created inbox'),
+    apiKey: z.string().describe('API key for authenticating subsequent requests. Store securely - it cannot be retrieved again'),
+})
+
+export const AgentVerifyResponseSchema = z.object({
+    verified: z.boolean().describe('Whether the organization was verified'),
+})

--- a/node/src/output-schemas.ts
+++ b/node/src/output-schemas.ts
@@ -206,12 +206,6 @@ export const IdentitySchema = z.object({
     apiKeyId: z.string().optional(),
 })
 
-export const AgentSignUpResponseSchema = z.object({
-    organizationId: z.string().describe('ID of the created organization'),
-    inboxId: z.string().describe('ID of the auto-created inbox'),
-    apiKey: z.string().describe('API key for authenticating subsequent requests. Store securely - it cannot be retrieved again'),
-})
-
 export const AgentVerifyResponseSchema = z.object({
     verified: z.boolean().describe('Whether the organization was verified'),
 })

--- a/node/src/schemas.ts
+++ b/node/src/schemas.ts
@@ -212,13 +212,6 @@ export const AuthMeParams = z.object({})
 
 // Agent schemas
 
-export const AgentSignUpParams = z.object({
-    humanEmail: z.string().describe('Email address of the human who owns the agent. A 6-digit verification code is emailed here.'),
-    username: z.string().describe('Username for the auto-created inbox (e.g. "my-agent" creates my-agent@agentmail.to)'),
-    source: z.string().optional().describe('The SDK, framework, or platform issuing this sign-up (e.g. "agentmail-mcp"). Identifies the caller'),
-    referrer: z.string().optional().describe('The channel that drove this sign-up — where the agent or its developer discovered AgentMail'),
-})
-
 export const AgentVerifyParams = z.object({
     otpCode: z.string().describe('6-digit verification code emailed to the human who signed up'),
 })

--- a/node/src/schemas.ts
+++ b/node/src/schemas.ts
@@ -209,3 +209,16 @@ export const DeleteDraftParams = z.object({
 })
 
 export const AuthMeParams = z.object({})
+
+// Agent schemas
+
+export const AgentSignUpParams = z.object({
+    humanEmail: z.string().describe('Email address of the human who owns the agent. A 6-digit verification code is emailed here.'),
+    username: z.string().describe('Username for the auto-created inbox (e.g. "my-agent" creates my-agent@agentmail.to)'),
+    source: z.string().optional().describe('The SDK, framework, or platform issuing this sign-up (e.g. "agentmail-mcp"). Identifies the caller'),
+    referrer: z.string().optional().describe('The channel that drove this sign-up — where the agent or its developer discovered AgentMail'),
+})
+
+export const AgentVerifyParams = z.object({
+    otpCode: z.string().describe('6-digit verification code emailed to the human who signed up'),
+})

--- a/node/src/tools.ts
+++ b/node/src/tools.ts
@@ -24,7 +24,6 @@ import {
     SendDraftParams,
     DeleteDraftParams,
     AuthMeParams,
-    AgentSignUpParams,
     AgentVerifyParams,
 } from './schemas.js'
 import {
@@ -43,7 +42,6 @@ import {
     DraftSchema,
     ListDraftsResponseSchema,
     IdentitySchema,
-    AgentSignUpResponseSchema,
     AgentVerifyResponseSchema,
 } from './output-schemas.js'
 import {
@@ -71,7 +69,6 @@ import {
     sendDraft,
     deleteDraft,
     authMe,
-    agentSignUp,
     agentVerify,
 } from './functions.js'
 
@@ -468,22 +465,6 @@ export const tools: Tool[] = [
             destructiveHint: false,
             idempotentHint: true,
             openWorldHint: false,
-        },
-    }),
-    defineTool({
-        name: 'agent_sign_up',
-        title: 'Agent Sign Up',
-        description:
-            "Sign up a new AgentMail agent organization, creating an inbox and an API key in one call. Use this the first time an agent needs AgentMail access — a 6-digit verification code is emailed to humanEmail; call agent_verify with it afterwards to remove the unverified plan's caps (1 inbox, 10 sends/day) at no cost. Calling this again with the same humanEmail rotates the API key and resends the code.",
-        paramsSchema: AgentSignUpParams,
-        outputSchema: AgentSignUpResponseSchema,
-        func: agentSignUp,
-        annotations: {
-            title: 'Agent Sign Up',
-            readOnlyHint: false,
-            destructiveHint: false,
-            idempotentHint: true,
-            openWorldHint: true,
         },
     }),
     defineTool({

--- a/node/src/tools.ts
+++ b/node/src/tools.ts
@@ -24,6 +24,8 @@ import {
     SendDraftParams,
     DeleteDraftParams,
     AuthMeParams,
+    AgentSignUpParams,
+    AgentVerifyParams,
 } from './schemas.js'
 import {
     ListInboxesResponseSchema,
@@ -41,6 +43,8 @@ import {
     DraftSchema,
     ListDraftsResponseSchema,
     IdentitySchema,
+    AgentSignUpResponseSchema,
+    AgentVerifyResponseSchema,
 } from './output-schemas.js'
 import {
     listInboxes,
@@ -67,6 +71,8 @@ import {
     sendDraft,
     deleteDraft,
     authMe,
+    agentSignUp,
+    agentVerify,
 } from './functions.js'
 
 // All five ToolAnnotations fields (title, readOnlyHint, destructiveHint, idempotentHint,
@@ -461,6 +467,38 @@ export const tools: Tool[] = [
             readOnlyHint: true,
             destructiveHint: false,
             idempotentHint: true,
+            openWorldHint: false,
+        },
+    }),
+    defineTool({
+        name: 'agent_sign_up',
+        title: 'Agent Sign Up',
+        description:
+            "Sign up a new AgentMail agent organization, creating an inbox and an API key in one call. Use this the first time an agent needs AgentMail access — a 6-digit verification code is emailed to humanEmail; call agent_verify with it afterwards to remove the unverified plan's caps (1 inbox, 10 sends/day) at no cost. Calling this again with the same humanEmail rotates the API key and resends the code.",
+        paramsSchema: AgentSignUpParams,
+        outputSchema: AgentSignUpResponseSchema,
+        func: agentSignUp,
+        annotations: {
+            title: 'Agent Sign Up',
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: true,
+        },
+    }),
+    defineTool({
+        name: 'agent_verify',
+        title: 'Agent Verify',
+        description:
+            'Verify an unverified agent organization using the 6-digit code emailed to the human who signed up, lifting the unverified plan\'s caps (1 inbox, 10 sends/day) at no cost. Call this when a plan-cap error tells you to verify — ask your human for the code from their email. The code expires after 24 hours and allows at most 10 attempts.',
+        paramsSchema: AgentVerifyParams,
+        outputSchema: AgentVerifyResponseSchema,
+        func: agentVerify,
+        annotations: {
+            title: 'Agent Verify',
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
             openWorldHint: false,
         },
     }),

--- a/node/src/util.ts
+++ b/node/src/util.ts
@@ -13,7 +13,7 @@ const MAX_ERROR_BODY_LENGTH = 500
 // bodies, and bounds the result so a large/unbounded body is never returned to callers.
 function apiErrorMessage(error: AgentMailError): string {
     const body = error.body as
-        | { message?: string; detail?: string; error?: string; name?: string; errors?: unknown[] }
+        | { message?: string; detail?: string; error?: string; name?: string; errors?: unknown[]; fix?: string }
         | string
         | undefined
     let detail: string | undefined
@@ -24,11 +24,24 @@ function apiErrorMessage(error: AgentMailError): string {
     } else if (body?.name === 'ValidationErrorResponse' && Array.isArray(body.errors)) {
         detail = `${body.name}: ${JSON.stringify(body.errors).slice(0, MAX_ERROR_BODY_LENGTH)}`
     }
+    // The API's own `fix` names the real remedy — the cap that was hit, the window it resets in,
+    // the tier that raises it and its price, or (for an unverified agent org) the verification
+    // call that lifts the cap for free. It is always better than a status-code guess, so when it
+    // is present it replaces the canned guidance below rather than sitting alongside it.
+    const fix = typeof body === 'object' && typeof body?.fix === 'string' ? body.fix : undefined
+
     const base = detail ?? error.message
-    const bounded = typeof base === 'string' && base.length > MAX_ERROR_BODY_LENGTH ? base.slice(0, MAX_ERROR_BODY_LENGTH) + '…' : base
+    const combined = fix ? `${base} — ${fix}` : base
+    const bounded =
+        typeof combined === 'string' && combined.length > MAX_ERROR_BODY_LENGTH
+            ? combined.slice(0, MAX_ERROR_BODY_LENGTH) + '…'
+            : combined
     const withStatus = error.statusCode ? `${bounded} (HTTP ${error.statusCode})` : bounded
-    // Action-specific guidance for the statuses a model can actually act on;
-    // everything else keeps the API's own explanation.
+
+    // Action-specific guidance for the statuses a model can actually act on. Skipped entirely when
+    // the API supplied a `fix`: a plan-cap 403 is not a permissions problem, and telling a model to
+    // "wait before retrying" a monthly send quota sends it down a road that does not end.
+    if (fix) return withStatus
     if (error.statusCode === 401) return `${withStatus} — credentials are missing or invalid; reconnect or provide a valid API key`
     if (error.statusCode === 403) return `${withStatus} — the authenticated credential lacks permission for this action`
     if (error.statusCode === 429) return `${withStatus} — rate limited; wait before retrying`

--- a/node/tests/contract.test.ts
+++ b/node/tests/contract.test.ts
@@ -20,9 +20,9 @@ describe('canonical tool catalog', () => {
     it('has unique names and deterministic ordering', () => {
         const names = tools.map((t) => t.name)
         expect(new Set(names).size).toBe(names.length)
-        // Grouped by resource: inboxes, threads, messages, drafts, auth.
+        // Grouped by resource: inboxes, threads, messages, drafts, auth, agent.
         expect(names[0]).toBe('list_inboxes')
-        expect(names[names.length - 1]).toBe('auth_me')
+        expect(names[names.length - 1]).toBe('agent_verify')
     })
 })
 

--- a/node/tests/fixtures.ts
+++ b/node/tests/fixtures.ts
@@ -89,7 +89,6 @@ export const sendResult = () => ({ messageId: 'msg_1', threadId: 'thread_1' })
 
 export const identity = () => ({ scopeType: 'organization' as const, scopeId: 'org_1', organizationId: 'org_1' })
 
-export const agentSignUpResult = () => ({ organizationId: 'org_1', inboxId: 'inbox_1', apiKey: 'am_test_key' })
 
 export const agentVerifyResult = () => ({ verified: true })
 
@@ -127,7 +126,6 @@ export const fixtureByTool: Record<string, () => unknown> = {
     send_draft: sendResult,
     delete_draft: success,
     auth_me: identity,
-    agent_sign_up: agentSignUpResult,
     agent_verify: agentVerifyResult,
 }
 
@@ -157,7 +155,6 @@ export const argsByTool: Record<string, Record<string, unknown>> = {
     send_draft: { inboxId: 'inbox_1', draftId: 'draft_1' },
     delete_draft: { inboxId: 'inbox_1', draftId: 'draft_1' },
     auth_me: {},
-    agent_sign_up: { humanEmail: 'human@example.com', username: 'my-agent' },
     agent_verify: { otpCode: '123456' },
 }
 
@@ -201,7 +198,6 @@ export function mockClient(overrides?: Record<string, unknown>): AgentMailClient
             me: async () => f.auth_me(),
         },
         agent: {
-            signUp: async () => f.agent_sign_up(),
             verify: async () => f.agent_verify(),
         },
         ...overrides,

--- a/node/tests/fixtures.ts
+++ b/node/tests/fixtures.ts
@@ -89,6 +89,10 @@ export const sendResult = () => ({ messageId: 'msg_1', threadId: 'thread_1' })
 
 export const identity = () => ({ scopeType: 'organization' as const, scopeId: 'org_1', organizationId: 'org_1' })
 
+export const agentSignUpResult = () => ({ organizationId: 'org_1', inboxId: 'inbox_1', apiKey: 'am_test_key' })
+
+export const agentVerifyResult = () => ({ verified: true })
+
 const success = () => ({ success: true as const })
 
 // One representative success fixture per tool, keyed by canonical tool name.
@@ -123,6 +127,8 @@ export const fixtureByTool: Record<string, () => unknown> = {
     send_draft: sendResult,
     delete_draft: success,
     auth_me: identity,
+    agent_sign_up: agentSignUpResult,
+    agent_verify: agentVerifyResult,
 }
 
 // Minimal valid arguments per tool (must satisfy each tool's paramsSchema).
@@ -151,6 +157,8 @@ export const argsByTool: Record<string, Record<string, unknown>> = {
     send_draft: { inboxId: 'inbox_1', draftId: 'draft_1' },
     delete_draft: { inboxId: 'inbox_1', draftId: 'draft_1' },
     auth_me: {},
+    agent_sign_up: { humanEmail: 'human@example.com', username: 'my-agent' },
+    agent_verify: { otpCode: '123456' },
 }
 
 // A fake AgentMailClient whose every method resolves with the matching fixture.
@@ -191,6 +199,10 @@ export function mockClient(overrides?: Record<string, unknown>): AgentMailClient
         },
         auth: {
             me: async () => f.auth_me(),
+        },
+        agent: {
+            signUp: async () => f.agent_sign_up(),
+            verify: async () => f.agent_verify(),
         },
         ...overrides,
     }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ description = "AgentMail Toolkit"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "agentmail>=0.4.10",
+    "agentmail>=0.4.13",
     "filetype>=1.2.0",
     "langchain>=1.1.0",
     "livekit-agents>=1.3.5",

--- a/python/src/agentmail_toolkit/functions.py
+++ b/python/src/agentmail_toolkit/functions.py
@@ -129,9 +129,5 @@ def update_message(client: AgentMail, kwargs: Kwargs):
     return client.inboxes.messages.update(**kwargs)
 
 
-def agent_sign_up(client: AgentMail, kwargs: Kwargs):
-    return client.agent.sign_up(**kwargs)
-
-
 def agent_verify(client: AgentMail, kwargs: Kwargs):
     return client.agent.verify(**kwargs)

--- a/python/src/agentmail_toolkit/functions.py
+++ b/python/src/agentmail_toolkit/functions.py
@@ -127,3 +127,11 @@ def forward_message(client: AgentMail, kwargs: Kwargs):
 
 def update_message(client: AgentMail, kwargs: Kwargs):
     return client.inboxes.messages.update(**kwargs)
+
+
+def agent_sign_up(client: AgentMail, kwargs: Kwargs):
+    return client.agent.sign_up(**kwargs)
+
+
+def agent_verify(client: AgentMail, kwargs: Kwargs):
+    return client.agent.verify(**kwargs)

--- a/python/src/agentmail_toolkit/schemas.py
+++ b/python/src/agentmail_toolkit/schemas.py
@@ -92,3 +92,24 @@ class UpdateMessageParams(BaseModel):
     message_id: MessageIdField
     add_labels: Optional[List[str]] = Field(default=None, description="Labels to add")
     remove_labels: Optional[List[str]] = Field(default=None, description="Labels to remove")
+
+
+class AgentSignUpParams(BaseModel):
+    human_email: str = Field(
+        description="Email address of the human who owns the agent. A 6-digit verification code is emailed here."
+    )
+    username: str = Field(
+        description='Username for the auto-created inbox (e.g. "my-agent" creates my-agent@agentmail.to)'
+    )
+    source: Optional[str] = Field(
+        default=None,
+        description='The SDK, framework, or platform issuing this sign-up (e.g. "agentmail-mcp"). Identifies the caller',
+    )
+    referrer: Optional[str] = Field(
+        default=None,
+        description="The channel that drove this sign-up — where the agent or its developer discovered AgentMail",
+    )
+
+
+class AgentVerifyParams(BaseModel):
+    otp_code: str = Field(description="6-digit verification code emailed to the human who signed up")

--- a/python/src/agentmail_toolkit/schemas.py
+++ b/python/src/agentmail_toolkit/schemas.py
@@ -94,22 +94,5 @@ class UpdateMessageParams(BaseModel):
     remove_labels: Optional[List[str]] = Field(default=None, description="Labels to remove")
 
 
-class AgentSignUpParams(BaseModel):
-    human_email: str = Field(
-        description="Email address of the human who owns the agent. A 6-digit verification code is emailed here."
-    )
-    username: str = Field(
-        description='Username for the auto-created inbox (e.g. "my-agent" creates my-agent@agentmail.to)'
-    )
-    source: Optional[str] = Field(
-        default=None,
-        description='The SDK, framework, or platform issuing this sign-up (e.g. "agentmail-mcp"). Identifies the caller',
-    )
-    referrer: Optional[str] = Field(
-        default=None,
-        description="The channel that drove this sign-up — where the agent or its developer discovered AgentMail",
-    )
-
-
 class AgentVerifyParams(BaseModel):
     otp_code: str = Field(description="6-digit verification code emailed to the human who signed up")

--- a/python/src/agentmail_toolkit/tools.py
+++ b/python/src/agentmail_toolkit/tools.py
@@ -13,7 +13,6 @@ from .schemas import (
     ReplyToMessageParams,
     UpdateMessageParams,
     ForwardMessageParams,
-    AgentSignUpParams,
     AgentVerifyParams,
 )
 from .functions import (
@@ -29,7 +28,6 @@ from .functions import (
     reply_to_message,
     update_message,
     forward_message,
-    agent_sign_up,
     agent_verify,
 )
 
@@ -107,18 +105,6 @@ tools: List[Tool] = [
         description="Update message",
         params_schema=UpdateMessageParams,
         func=update_message,
-    ),
-    Tool(
-        name="agent_sign_up",
-        description=(
-            "Sign up a new AgentMail agent organization, creating an inbox and an API key in one call. "
-            "Use this the first time an agent needs AgentMail access — a 6-digit verification code is "
-            "emailed to human_email; call agent_verify with it afterwards to remove the unverified "
-            "plan's caps (1 inbox, 10 sends/day) at no cost. Calling this again with the same "
-            "human_email rotates the API key and resends the code."
-        ),
-        params_schema=AgentSignUpParams,
-        func=agent_sign_up,
     ),
     Tool(
         name="agent_verify",

--- a/python/src/agentmail_toolkit/tools.py
+++ b/python/src/agentmail_toolkit/tools.py
@@ -13,6 +13,8 @@ from .schemas import (
     ReplyToMessageParams,
     UpdateMessageParams,
     ForwardMessageParams,
+    AgentSignUpParams,
+    AgentVerifyParams,
 )
 from .functions import (
     Kwargs,
@@ -27,6 +29,8 @@ from .functions import (
     reply_to_message,
     update_message,
     forward_message,
+    agent_sign_up,
+    agent_verify,
 )
 
 
@@ -103,5 +107,28 @@ tools: List[Tool] = [
         description="Update message",
         params_schema=UpdateMessageParams,
         func=update_message,
+    ),
+    Tool(
+        name="agent_sign_up",
+        description=(
+            "Sign up a new AgentMail agent organization, creating an inbox and an API key in one call. "
+            "Use this the first time an agent needs AgentMail access — a 6-digit verification code is "
+            "emailed to human_email; call agent_verify with it afterwards to remove the unverified "
+            "plan's caps (1 inbox, 10 sends/day) at no cost. Calling this again with the same "
+            "human_email rotates the API key and resends the code."
+        ),
+        params_schema=AgentSignUpParams,
+        func=agent_sign_up,
+    ),
+    Tool(
+        name="agent_verify",
+        description=(
+            "Verify an unverified agent organization using the 6-digit code emailed to the human who "
+            "signed up, lifting the unverified plan's caps (1 inbox, 10 sends/day) at no cost. Call "
+            "this when a plan-cap error tells you to verify — ask your human for the code from their "
+            "email. The code expires after 24 hours and allows at most 10 attempts."
+        ),
+        params_schema=AgentVerifyParams,
+        func=agent_verify,
     ),
 ]

--- a/python/src/agentmail_toolkit/util.py
+++ b/python/src/agentmail_toolkit/util.py
@@ -39,5 +39,14 @@ def api_error_message(error: BaseException) -> str:
             if errors is not None:
                 detail = str(errors)
 
-    base = _bounded(detail or type(error).__name__)
+    # The API's own `fix` names the real remedy - the cap that was hit, the window it
+    # resets in, the tier that raises it and its price, or (for an unverified agent org)
+    # the verification call that lifts the cap for free. Always better than a status-code
+    # guess, so it is appended before bounding. Mirrors node/src/util.ts.
+    fix = body.get("fix") if isinstance(body, dict) else getattr(body, "fix", None)
+    combined = detail or type(error).__name__
+    if isinstance(fix, str) and fix:
+        combined = f"{combined} — {fix}"
+
+    base = _bounded(combined)
     return f"{base} (HTTP {error.status_code})" if error.status_code else base

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -121,15 +121,6 @@ def test_update_message_call_shape(mock_client):
     )
 
 
-def test_agent_sign_up_call_shape(mock_client):
-    functions.agent_sign_up(
-        mock_client, {"human_email": "human@example.com", "username": "my-agent"}
-    )
-    mock_client.agent.sign_up.assert_called_once_with(
-        human_email="human@example.com", username="my-agent"
-    )
-
-
 def test_agent_verify_call_shape(mock_client):
     functions.agent_verify(mock_client, {"otp_code": "123456"})
     mock_client.agent.verify.assert_called_once_with(otp_code="123456")

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -121,6 +121,20 @@ def test_update_message_call_shape(mock_client):
     )
 
 
+def test_agent_sign_up_call_shape(mock_client):
+    functions.agent_sign_up(
+        mock_client, {"human_email": "human@example.com", "username": "my-agent"}
+    )
+    mock_client.agent.sign_up.assert_called_once_with(
+        human_email="human@example.com", username="my-agent"
+    )
+
+
+def test_agent_verify_call_shape(mock_client):
+    functions.agent_verify(mock_client, {"otp_code": "123456"})
+    mock_client.agent.verify.assert_called_once_with(otp_code="123456")
+
+
 def test_get_inbox_passes_through_real_sdk_model(mock_client):
     """Serialization: the function must return the real SDK model unchanged
     (not unwrap/rewrap it), so downstream .model_dump_json() calls work."""


### PR DESCRIPTION
## Why

[agentmail-api#834](https://github.com/agentmail-to/agentmail-api/pull/834) (merged) made plan-cap and send-quota errors self-describing. The body now carries a `fix` naming the cap that was hit, the window it resets in, and the tier that raises it with its price — or, for an unverified agent-plan org, the verification call that raises it **for free**.

None of it reached a model, and this repo is why. Every MCP surface funnels through `apiErrorMessage`: the hosted `mcp.agentmail.to` server, `agentmail-manufact-mcp`, and every framework adapter (ai-sdk, langchain, clawdbot, openai-agents, livekit).

## What a model saw

```
Inbox limit exceeded (HTTP 403) — the authenticated credential lacks permission for this action
```

Two failures. `fix`, `upgrade_url`, `resource`, `limit` and `window` were dropped by the body cast. Then the 403 line **replaced** the API's explanation with a wrong diagnosis — a model told its credential lacks permission will retry with different credentials or abandon the task. It will not tell its human to upgrade. The 429 line failed the same way: "wait before retrying" is not advice that terminates against a monthly quota.

## What it sees now

```
Inbox limit exceeded — Your plan's inbox limit is 3. Delete an existing inbox, or upgrade at
https://console.agentmail.to/dashboard/upgrade — Developer raises it to 10 for $20.00/month. (HTTP 403)
```

`fix` wins when present, and the canned status guidance is **skipped rather than appended** — on these statuses it is not a fallback, it is a contradiction. The 500-char cap moved after concatenation so a long remedy truncates cleanly instead of blowing the bound. 401 and every other status are untouched, as is the `ValidationErrorResponse` path.

## `agent_verify`

The agent-plan remedy says to call `POST /v0/agent/verify`. No tool exposed it — the SDK has `client.agent.verify()`, the catalog did not. So an unverified agent hitting its 1-inbox / 10-per-day cap was told to verify and had nothing to verify with.

The reachable path: an agent signs up against the API directly, gets back an api key, connects to MCP with it, trips the cap, and can now clear it without leaving the protocol.

**`agent_sign_up` was in the first draft and has been removed** — it is unreachable by construction. `packages/server/src/index.ts:645` 401s with `WWW-Authenticate` before any tool runs when no credential is present, so calling it requires auth, and holding auth means already having an organization.

**Python floor moves to `agentmail>=0.4.13`** — the first published release that actually ships the `agent` resource, verified against the wheels rather than assumed. At the old `>=0.4.10` floor an install could resolve to an SDK without `client.agent` and fail at the call rather than at install.

## Verification

`pnpm build && pnpm lint && pnpm test` → **280/280** · `pytest` → **34/34**. Node and Python kept at parity per the repo's invariant. No existing tool modified; the catalog contract test updated for the addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)