### PR TITLE
Release 0.6.1 (node) and 0.3.2 (python)

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agentmail-toolkit",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "AgentMail Toolkit",
     "scripts": {
         "build": "tsup",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentmail-toolkit"
-version = "0.3.1"
+version = "0.3.2"
 description = "AgentMail Toolkit"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bumps for the error-message fix in #50 — the API's `fix` now reaches the model, and the canned status guidance no longer overwrites it.

**npm `agentmail-toolkit@0.6.1` is already published.** This commit makes the repo agree with the registry.

**PyPI is a separate story.** Latest there is **0.3.0**, uploaded 2026-07-13. `0.3.1` was bumped in `3516bae` and never actually uploaded, so the Python package has been a release behind for a month. The blocker is permissions, not process: the account cutting releases is not a maintainer on the `agentmail-toolkit` PyPI project, so a project-scoped token cannot even be created for it. Recording the bump to `0.3.2` here so the repo and registry line up once that is granted — the built and `twine check`-passing artifacts are ready.

Note this does **not** gate the MCP fix. The hosted server is Node and consumes the npm package; PyPI `agentmail-mcp` is the stdio bridge, which proxies and does no error formatting. The Python toolkit publish matters only for direct LangChain / OpenAI Agents / LiveKit users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)