### PR TITLE
Add CI workflow for node and python packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # `defaults.run.working-directory` does not apply to action inputs, so
+      # the pnpm version has to be read from node/package.json explicitly.
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: node/package.json
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Both jobs run on every PR, with no `paths:` filters. A skipped job never
+# reports a conclusion, so a path-filtered job can never satisfy a required
+# status check and would leave PRs blocked indefinitely.
+jobs:
+  node:
+    name: node
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: node
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: node/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+
+      - run: pnpm build
+
+      - run: pnpm test
+
+  python:
+    name: python
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: python/uv.lock
+
+      - run: uv sync --frozen
+
+      - run: uv run pytest


### PR DESCRIPTION
Adds `.github/workflows/ci.yml`. This repository only had Dependency Graph and CodeQL — no PR-triggered CI — so every merged PR was recorded as merged without automated checks.

**What runs**, on every pull request and on pushes to `main`:

| Job | Steps |
|---|---|
| `node` | `pnpm install --frozen-lockfile` → `pnpm lint` → `pnpm build` → `pnpm test` |
| `python` | `uv sync --frozen` → `uv run pytest` |

`pnpm/action-setup` picks up `packageManager` (pnpm 10.6.4); Python comes from `requires-python >=3.11`.

Verified locally against this commit: node lint and build succeed with **280 tests passing** across 5 files, and python passes **34 tests**.

Both jobs deliberately run without `paths:` filters — a skipped job never reports a conclusion, so a path-filtered job can never satisfy a required status check and would leave PRs blocked indefinitely.

Job names are `node` and `python`, so they can be named as required status checks once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)