### PR TITLE
Clear the langchain and ajv advisories

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -88,6 +88,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@langchain/core": "^1.1.8",
         "@mariozechner/pi-agent-core": "^0.50.1",
         "@sinclair/typebox": "^0.34.47",
         "@types/node": "^24.10.1",
@@ -135,7 +136,11 @@
             "tar": ">=7.5.18",
             "undici": ">=7.29.0",
             "uuid": ">=11.1.1",
-            "ws": ">=8.21.0"
+            "ws": ">=8.21.0",
+            "langchain": ">=1.2.3 <1.3.0",
+            "ajv": ">=8.18.0",
+            "@eslint/eslintrc>ajv": "^6.12.6",
+            "eslint>ajv": "^6.12.6"
         }
     }
 }

--- a/node/pnpm-lock.yaml
+++ b/node/pnpm-lock.yaml
@@ -37,6 +37,10 @@ overrides:
   undici: '>=7.29.0'
   uuid: '>=11.1.1'
   ws: '>=8.21.0'
+  langchain: '>=1.2.3 <1.3.0'
+  ajv: '>=8.18.0'
+  '@eslint/eslintrc>ajv': ^6.12.6
+  eslint>ajv: ^6.12.6
 
 importers:
 
@@ -52,8 +56,8 @@ importers:
         specifier: ^3.10.1
         version: 3.10.1
       langchain:
-        specifier: ^1.2.0
-        version: 1.2.2(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.2.1))
+        specifier: '>=1.2.3 <1.3.0'
+        version: 1.2.39(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
       unpdf:
         specifier: ^1.4.0
         version: 1.4.0(@napi-rs/canvas@0.1.88)
@@ -64,6 +68,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.2
+      '@langchain/core':
+        specifier: ^1.1.8
+        version: 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
       '@mariozechner/pi-agent-core':
         specifier: ^0.50.1
         version: 0.50.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.2.1))(ws@8.21.0)(zod@4.2.1)
@@ -108,19 +115,19 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: 3.0.84
-        version: 3.0.84(zod@4.2.1)
+        version: 3.0.84(zod@4.3.6)
       '@langchain/openai':
         specifier: ^1.2.0
-        version: 1.2.0(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(ws@8.21.0)
+        version: 1.2.0(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)
       agentmail-toolkit:
         specifier: workspace:*
         version: link:..
       ai:
         specifier: 6.0.224
-        version: 6.0.224(zod@4.2.1)
+        version: 6.0.224(zod@4.3.6)
       langchain:
-        specifier: ^1.2.0
-        version: 1.2.2(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.2.1))
+        specifier: '>=1.2.3 <1.3.0'
+        version: 1.2.39(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
 
 packages:
 
@@ -790,46 +797,49 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@langchain/core@1.1.7':
-    resolution: {integrity: sha512-NSZSi33+V/8RVv1szsUiX7u+jXVCDImr2VO74SiKgJrhyxXKdJcxa3HMPKwdU+tkgQ6T+R7wxVYQ1Cnd4Z48tA==}
+  '@langchain/core@1.2.8':
+    resolution: {integrity: sha512-ppi2UaCYKqM4LEY8NWQ/JZ0Of0MAngHRvclceVeEQklcD/M6QKanlHPWblDnLO2m4vz7987b1Z4r33Ps6lf/ig==}
     engines: {node: '>=20'}
 
-  '@langchain/langgraph-checkpoint@1.0.0':
-    resolution: {integrity: sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==}
+  '@langchain/langgraph-checkpoint@1.1.3':
+    resolution: {integrity: sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.0.1
+      '@langchain/core': ^1.1.48
 
-  '@langchain/langgraph-sdk@1.3.1':
-    resolution: {integrity: sha512-zTi7DZHwqtMEzapvm3I1FL4Q7OZsxtq9tTXy6s2gcCxyIU3sphqRboqytqVN7dNHLdTCLb8nXy49QKurs2MIBg==}
+  '@langchain/langgraph-sdk@1.9.29':
+    resolution: {integrity: sha512-W+ccugM5EzBHvaOieyYxlSbhAy6HWF8Tyn6b/BlTWuFd8xtcnQOz2WuFyofcAc9+aQHE+6yHJfIywGOvjxS+bA==}
     peerDependencies:
-      '@langchain/core': ^1.0.1
+      '@langchain/core': ^1.1.48
       react: ^18 || ^19
       react-dom: ^18 || ^19
+      svelte: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
     peerDependenciesMeta:
-      '@langchain/core':
-        optional: true
       react:
         optional: true
       react-dom:
         optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
-  '@langchain/langgraph@1.0.7':
-    resolution: {integrity: sha512-EBGqNOWoRiEoLUaeuiXRpUM8/DE6QcwiirNyd97XhezStebBoTTilWH8CUt6S94JRGl5zwfBBRHfzotDnZS/eA==}
+  '@langchain/langgraph@1.4.10':
+    resolution: {integrity: sha512-QBNbbIWDp3pcyvaINGEYHdekGYSQm6ZYuC9/h7arEAZckAl5mRLaoRGw5t61V4Bf+rspEj2VcylqNAN3fcdBNQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.0.1
-      zod: ^3.25.32 || ^4.1.0
-      zod-to-json-schema: ^3.x
-    peerDependenciesMeta:
-      zod-to-json-schema:
-        optional: true
+      '@langchain/core': ^1.1.48
+      zod: ^3.25.32 || ^4.2.0
 
   '@langchain/openai@1.2.0':
     resolution: {integrity: sha512-r2g5Be3Sygw7VTJ89WVM/M94RzYToNTwXf8me1v+kgKxzdHbd/8XPYDFxpXEp3REyPgUrtJs+Oplba9pkTH5ug==}
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.0.0
+
+  '@langchain/protocol@0.0.18':
+    resolution: {integrity: sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==}
 
   '@line/bot-sdk@10.6.0':
     resolution: {integrity: sha512-4hSpglL/G/cW2JCcohaYz/BS0uOSJNV9IEYdMm0EiPEvDLayoI2hGq2D86uYPQFD2gvgkyhmzdShpWLG3P5r3w==}
@@ -2036,7 +2046,7 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: '>=8.18.0'
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -2044,8 +2054,8 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@6.2.1:
     resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
@@ -2062,10 +2072,6 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-
-  ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
-    engines: {node: '>=10'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -2186,10 +2192,6 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-
-  camelcase@6.3.0:
-    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
-    engines: {node: '>=10'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -2361,10 +2363,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2916,6 +2914,10 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -3021,11 +3023,11 @@ packages:
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
-  langchain@1.2.2:
-    resolution: {integrity: sha512-oa49AJGTE0MM5IlSvw70fQr2Ot/1LPRvHdSYWj0oGeeTVUalIwWYOpp9KbSW7eYUu7kgIviy4oUMo+KzXCj7Iw==}
+  langchain@1.2.39:
+    resolution: {integrity: sha512-3foM0VptB5NFnd3drLTVieZhNBcITS/9lnaKzfGgJ7a7YL0eEAM0ZHofMOi86V2KbpeSaHrJ08vOOMSc+CpfEQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': 1.1.7
+      '@langchain/core': ^1.1.38
 
   langsmith@0.8.11:
     resolution: {integrity: sha512-dNKtyEiNS6L10qsRGKExQVHoMsRGBJt+xiBHn6G8JxslapedUhXVkvcDkhi00EuiIMeil+RevAVG8k6VM0B9ew==}
@@ -3460,6 +3462,10 @@ packages:
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -4390,11 +4396,18 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.2.1
 
-  '@ai-sdk/openai@3.0.84(zod@4.2.1)':
+  '@ai-sdk/gateway@3.0.148(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.38(zod@4.2.1)
-      zod: 4.2.1
+      '@ai-sdk/provider-utils': 4.0.38(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/openai@3.0.84(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.38(zod@4.3.6)
+      zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.38(zod@4.2.1)':
     dependencies:
@@ -4402,6 +4415,13 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 4.2.1
+
+  '@ai-sdk/provider-utils@4.0.38(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.3.6
 
   '@ai-sdk/provider@3.0.14':
     dependencies:
@@ -5307,17 +5327,14 @@ snapshots:
   '@kwsites/promise-deferred@1.1.1':
     optional: true
 
-  '@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)':
+  '@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
+      '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
       langsmith: 0.8.11(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
       mustache: 4.2.0
       p-queue: 6.6.2
-      uuid: 14.0.1
       zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -5326,40 +5343,84 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))':
+  '@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)':
     dependencies:
-      '@langchain/core': 1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
-      uuid: 14.0.1
-
-  '@langchain/langgraph-sdk@1.3.1(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))':
-    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.8.11(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      mustache: 4.2.0
       p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 14.0.1
-    optionalDependencies:
-      '@langchain/core': 1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
 
-  '@langchain/langgraph@1.0.7(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.2.1))(zod@4.2.1)':
+  '@langchain/langgraph-checkpoint@1.1.3(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))':
     dependencies:
-      '@langchain/core': 1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))
-      '@langchain/langgraph-sdk': 1.3.1(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))
-      uuid: 14.0.1
-      zod: 4.2.1
-    optionalDependencies:
-      zod-to-json-schema: 3.25.1(zod@4.2.1)
+      '@langchain/core': 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
+
+  '@langchain/langgraph-checkpoint@1.1.3(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
+    dependencies:
+      '@langchain/core': 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+
+  '@langchain/langgraph-sdk@1.9.29(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))':
+    dependencies:
+      '@langchain/core': 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
+      '@langchain/protocol': 0.0.18
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.0
+      p-retry: 7.1.1
+
+  '@langchain/langgraph-sdk@1.9.29(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
+    dependencies:
+      '@langchain/core': 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      '@langchain/protocol': 0.0.18
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.0
+      p-retry: 7.1.1
+
+  '@langchain/langgraph@1.4.10(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(zod@4.3.6)':
+    dependencies:
+      '@langchain/core': 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
+      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))
+      '@langchain/langgraph-sdk': 1.9.29(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))
+      '@langchain/protocol': 0.0.18
+      '@standard-schema/spec': 1.1.0
+      zod: 4.3.6
     transitivePeerDependencies:
       - react
       - react-dom
+      - svelte
+      - vue
 
-  '@langchain/openai@1.2.0(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(ws@8.21.0)':
+  '@langchain/langgraph@1.4.10(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
+      '@langchain/core': 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+      '@langchain/langgraph-sdk': 1.9.29(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+      '@langchain/protocol': 0.0.18
+      '@standard-schema/spec': 1.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svelte
+      - vue
+
+  '@langchain/openai@1.2.0(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)':
+    dependencies:
+      '@langchain/core': 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       js-tiktoken: 1.0.21
       openai: 6.15.0(ws@8.21.0)(zod@4.2.1)
       zod: 4.2.1
     transitivePeerDependencies:
       - ws
+
+  '@langchain/protocol@0.0.18': {}
 
   '@line/bot-sdk@10.6.0':
     dependencies:
@@ -5474,8 +5535,8 @@ snapshots:
       '@google/genai': 1.34.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.2.1))
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       chalk: 5.6.2
       openai: 6.10.0(ws@8.21.0)(zod@4.3.6)
       partial-json: 0.1.7
@@ -5496,8 +5557,8 @@ snapshots:
       '@google/genai': 1.34.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.2.1))
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       chalk: 5.6.2
       openai: 6.10.0(ws@8.21.0)(zod@4.2.1)
       partial-json: 0.1.7
@@ -5563,8 +5624,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.2)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
@@ -6729,9 +6790,17 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.2.1
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ai@6.0.224(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.148(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.38(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
   ajv@6.12.6:
     dependencies:
@@ -6740,7 +6809,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.17.1:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 4.1.2
@@ -6757,8 +6826,6 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
 
@@ -6881,8 +6948,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase@6.3.0: {}
-
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -6934,7 +6999,7 @@ snapshots:
       '@slack/bolt': 4.6.0(@types/express@5.0.6)
       '@slack/web-api': 7.13.0
       '@whiskeysockets/baileys': 7.0.0-rc14(sharp@0.35.3(@types/node@24.10.4))
-      ajv: 8.17.1
+      ajv: 8.20.0
       body-parser: 2.3.0
       chalk: 5.6.2
       chokidar: 5.0.0
@@ -7115,8 +7180,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decamelize@1.2.0: {}
 
   deep-extend@0.6.0:
     optional: true
@@ -7781,6 +7844,8 @@ snapshots:
   is-interactive@2.0.0:
     optional: true
 
+  is-network-error@1.3.2: {}
+
   is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
@@ -7893,14 +7958,14 @@ snapshots:
     dependencies:
       '@keyv/serialize': 1.1.1
 
-  langchain@1.2.2(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.2.1)):
+  langchain@1.2.39(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0):
     dependencies:
-      '@langchain/core': 1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
-      '@langchain/langgraph': 1.0.7(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.2.1))(zod@4.2.1)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.7(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))
+      '@langchain/core': 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
+      '@langchain/langgraph': 1.4.10(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0))
       langsmith: 0.8.11(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0)
       uuid: 14.0.1
-      zod: 4.2.1
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -7908,8 +7973,28 @@ snapshots:
       - openai
       - react
       - react-dom
+      - svelte
+      - vue
       - ws
-      - zod-to-json-schema
+
+  langchain@1.2.39(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0):
+    dependencies:
+      '@langchain/core': 1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      '@langchain/langgraph': 1.4.10(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.8(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+      langsmith: 0.8.11(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      uuid: 14.0.1
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
 
   langsmith@0.8.11(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.2.1))(ws@8.21.0):
     dependencies:
@@ -7917,6 +8002,14 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       openai: 6.15.0(ws@8.21.0)(zod@4.2.1)
+      ws: 8.21.0
+
+  langsmith@0.8.11(@opentelemetry/api@1.9.0)(openai@6.15.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0):
+    dependencies:
+      p-queue: 6.6.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      openai: 6.15.0(ws@8.21.0)(zod@4.3.6)
       ws: 8.21.0
 
   levn@0.4.1:
@@ -8298,6 +8391,12 @@ snapshots:
       ws: 8.21.0
       zod: 4.2.1
 
+  openai@6.15.0(ws@8.21.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.3.6
+    optional: true
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -8346,6 +8445,10 @@ snapshots:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.2
 
   p-timeout@3.2.0:
     dependencies:


### PR DESCRIPTION
Three advisories were left open in #54 because the obvious fixes broke the build. All three turn out to be resolvable with more precise constraints.

| Package | Was | Now | How |
|---|---|---|---|
| `langchain` | 1.2.2 | **1.2.39** | bounded `>=1.2.3 <1.3.0` |
| `@langchain/core` | 1.1.7 | **1.2.8** | declared as devDependency |
| `ajv` | 8.17.1 | **8.20.0** | override + eslint scoped to ^6.12.6 |

**langchain.** The advisories are satisfied by 1.2.3 / 1.1.8. The open-ended `>=` I used before resolved to `langchain@1.5.9`, which imports a `@langchain/core` subpath that core 1.1.x does not export — hence the earlier test failures. A bounded range keeps it on the 1.2 line.

`@langchain/core` is an **auto-installed peer**, and pnpm does not apply overrides to those — it silently stayed on 1.1.7. Declaring it explicitly is what actually moves it. (Same trap as `vite` in agentmail-node#27.)

**ajv.** 8.18 is required by the `@modelcontextprotocol/sdk` tree, but both `eslint` and `@eslint/eslintrc` call an older ajv API and crash on 8.x. Scoping just those two back to `^6.12.6` lets the rest of the tree move forward.

Verified with `pnpm@10.6.4`: lint clean, build clean, **280 tests pass**, clean `--frozen-lockfile` install succeeds.

Leaves 16 open on this repo — 14 `clawdbot` and 2 `@mariozechner/pi-coding-agent`, none of which have a published fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)